### PR TITLE
tests will break when pytest upgrades implicitly on travis, let's pin the version for now.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     setuptools>=7.0  # to avoid .egg directories
     pytest-cov
     py26: argparse
+    py26: pytest==2.7.1
 commands =
     python setup.py test -a "--cov attr --cov-report term-missing"
 


### PR DESCRIPTION
This is a temporary fix for #14 .