### PR TITLE
Support optional values through a new validator.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ The following folks helped forming ``attrs`` into what it is now:
 - `Glyph <https://github.com/glyph/>`_
 - `HawkOwl <https://github.com/hawkowl>`_
 - `Lynn Root <https://github.com/econchick>`_
+- `Samuel A. Falvo II <https://github.com/sam-falvo>`_
 - `Wouter Bolsterlee <https://github.com/wbolster/>`_
 
 Of course ``characteristic``\ ’s `hall of fame <https://characteristic.readthedocs.org/en/stable/license.html>`_ applies as well since they share a lot of code.

--- a/attr/validators.py
+++ b/attr/validators.py
@@ -89,10 +89,6 @@ def provides(interface):
 
 @attributes(repr=False)
 class _OptionalValidator(object):
-    """
-    A validator that makes an attribute optional.  An optional field is one
-    which can be set to None in addition to its intended data type.
-    """
     validator = attr()
 
     def __call__(self, inst, attr, value):
@@ -109,8 +105,9 @@ class _OptionalValidator(object):
 
 def optional(validator):
     """
-    A validator that makes an attribute optional.  An optional field is one
-    which can be set to None in addition to its intended data type.
+    A validator that makes an attribute optional.  An optional attribute is one
+    which can be set to None in addition to satisfying the requirements of the
+    sub-validator.
 
     :param validator: Any other validator you wish to make optional.
     """

--- a/attr/validators.py
+++ b/attr/validators.py
@@ -85,3 +85,33 @@ def provides(interface):
     the value it got.
     """
     return _ProvidesValidator(interface)
+
+
+@attributes(repr=False)
+class _OptionalValidator(object):
+    """
+    A validator that makes an attribute optional.  An optional field is one
+    which can be set to None in addition to its intended data type.
+    """
+    v = attr()
+
+    def __call__(self, inst, attr, value):
+        if value is None:
+            return
+        return self.v(inst, attr, value)
+
+    def __repr__(self):
+        return (
+            "<optional validator for {type} or None>"
+            .format(type=repr(self.v))
+        )
+
+
+def optional(x):
+    """
+    A validator that makes an attribute optional.  An optional field is one
+    which can be set to None in addition to its intended data type.
+
+    :param x: Any other validator you wish to make optional.
+    """
+    return _OptionalValidator(x)

--- a/attr/validators.py
+++ b/attr/validators.py
@@ -93,25 +93,25 @@ class _OptionalValidator(object):
     A validator that makes an attribute optional.  An optional field is one
     which can be set to None in addition to its intended data type.
     """
-    v = attr()
+    validator = attr()
 
     def __call__(self, inst, attr, value):
         if value is None:
             return
-        return self.v(inst, attr, value)
+        return self.validator(inst, attr, value)
 
     def __repr__(self):
         return (
             "<optional validator for {type} or None>"
-            .format(type=repr(self.v))
+            .format(type=repr(self.validator))
         )
 
 
-def optional(x):
+def optional(validator):
     """
     A validator that makes an attribute optional.  An optional field is one
     which can be set to None in addition to its intended data type.
 
-    :param x: Any other validator you wish to make optional.
+    :param validator: Any other validator you wish to make optional.
     """
-    return _OptionalValidator(x)
+    return _OptionalValidator(validator)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -226,6 +226,29 @@ Validators
       Traceback (most recent call last):
          ...
       TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>), <type 'int'>, '42')
+      >>> C(None)
+      Traceback (most recent call last):
+         ...
+      TypeError: ("'x' must be <type 'int'> (got None that is a <type 'NoneType'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, repr=True, cmp=True, hash=True, init=True), <type 'int'>, None)
 
 
 .. autofunction:: attr.validators.provides
+
+.. autofunction:: attr.validators.optional
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(int)))
+      >>> C(42)
+      C(x=42)
+      >>> C("42")
+      Traceback (most recent call last):
+         ...
+      TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>), <type 'int'>, '42')
+      >>> C(None)
+      C(x=None)
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,9 +16,7 @@ The third digit is only for regressions.
 Changes:
 ^^^^^^^^
 
-- Add optional_ validator.
-
-.. _optional: http://attrs.readthedocs.org/en/stable/api.html#validators
+- Add :func:`attr.validators.optional` that wraps other validators allowing attributes to be ``None``.
 
 
 15.0.0 (2015-04-15)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,9 @@ The third digit is only for regressions.
 Changes:
 ^^^^^^^^
 
-- Add optional validator.
+- Add optional_ validator.
+
+.. _optional: http://attrs.readthedocs.org/en/stable/api.html#validators
 
 
 15.0.0 (2015-04-15)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,7 @@ The third digit is only for regressions.
 Changes:
 ^^^^^^^^
 
-- none yet
+- Add optional validator.
 
 
 15.0.0 (2015-04-15)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import zope.interface
 
-from attr.validators import instance_of, provides
+from attr.validators import instance_of, provides, optional
 from attr._compat import TYPE
 from . import simple_attr
 
@@ -107,4 +107,75 @@ class TestProvides(object):
         assert (
             "<provides validator for interface {interface!r}>"
             .format(interface=IFoo)
+        ) == repr(v)
+
+
+class TestOptional(object):
+    """
+    Tests for `optional`.
+    """
+    def test_success_with_type(self):
+        """
+        Nothing happens if types match.
+        """
+        v = optional(instance_of(int))
+        v(None, simple_attr("test"), 42)
+
+    def test_success_with_none(self):
+        """
+        Nothing happens if None.
+        """
+        v = optional(instance_of(int))
+        v(None, simple_attr("test"), None)
+
+    def test_subclass(self):
+        """
+        Subclasses are accepted too.
+        """
+        v = optional(instance_of(int))
+        v(None, simple_attr("test"), True)
+
+    def test_given_interface(self):
+        """
+        Nothing happens if value provides requested interface.
+        """
+        @zope.interface.implementer(IFoo)
+        class C(object):
+            def f(self):
+                pass
+
+        v = optional(provides(IFoo))
+        v(None, simple_attr("x"), C())
+
+    def test_no_interface(self):
+        """
+        Nothing happens if None passed for an interface too.
+        """
+        v = optional(provides(IFoo))
+        v(None, simple_attr("x"), None)
+
+    def test_fail(self):
+        """
+        Raises `TypeError` on wrong types.
+        """
+        v = optional(instance_of(int))
+        a = simple_attr("test")
+        with pytest.raises(TypeError) as e:
+            v(None, a, "42")
+        assert (
+            "'test' must be <{type} 'int'> (got '42' that is a <{type} "
+            "'str'>).".format(type=TYPE),
+            a, int, "42",
+
+        ) == e.value.args
+
+    def test_repr(self):
+        """
+        Returned validator has a useful `__repr__`.
+        """
+        v = optional(instance_of(int))
+        assert (
+            ("<optional validator for <instance_of validator for type "
+             "<{type} 'int'>> or None>")
+            .format(type=TYPE)
         ) == repr(v)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -135,25 +135,6 @@ class TestOptional(object):
         v = optional(instance_of(int))
         v(None, simple_attr("test"), True)
 
-    def test_given_interface(self):
-        """
-        Nothing happens if value provides requested interface.
-        """
-        @zope.interface.implementer(IFoo)
-        class C(object):
-            def f(self):
-                pass
-
-        v = optional(provides(IFoo))
-        v(None, simple_attr("x"), C())
-
-    def test_no_interface(self):
-        """
-        Nothing happens if None passed for an interface too.
-        """
-        v = optional(provides(IFoo))
-        v(None, simple_attr("x"), None)
-
     def test_fail(self):
         """
         Raises `TypeError` on wrong types.


### PR DESCRIPTION
Unfortunately, I'm unable to run tests locally b/c of severe dependency
hell.  I am unable to get tox, detox, python setup.py test, and other
means of running tests to work at all.  So, since I'm blocked on a
project by the lack of optional validator support, I am going to close
my eyes, look away, and pull the trigger, and hope I hit the target.

If someone who has a working Python configuration can please be kind
enough to let me know if my changes fail any tests, I'd be very
appreciative.

Even better, I'd love to know why a stock Python distribution with
dependencies installed is incapable of running the tests for attrs.
However, this isn't the right forum to answer that question.

(This PR has the 17+ debugging commits cleaned up.)