### PR TITLE
Fix the repr to work for non-redecorated subclass.

### DIFF
--- a/attr/_make.py
+++ b/attr/_make.py
@@ -303,19 +303,20 @@ def _add_repr(cl, ns=None, attrs=None):
     if attrs is None:
         attrs = [a for a in cl.__attrs_attrs__ if a.repr]
 
-    if ns is None:
-        qualname = getattr(cl, "__qualname__", None)
-        if qualname is not None:
-            class_name = qualname.rsplit(">.", 1)[-1]  # pragma: nocover
-        else:
-            class_name = cl.__name__
-    else:
-        class_name = ns + "." + cl.__name__
-
     def repr_(self):
         """
         Automatically created by attrs.
         """
+        real_cl = self.__class__
+        if ns is None:
+            qualname = getattr(real_cl, "__qualname__", None)
+            if qualname is not None:
+                class_name = qualname.rsplit(">.", 1)[-1]  # pragma: nocover
+            else:
+                class_name = real_cl.__name__
+        else:
+            class_name = ns + "." + real_cl.__name__
+
         return "{0}({1})".format(
             class_name,
             ", ".join(a.name + "=" + repr(getattr(self, a.name))

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -94,12 +94,26 @@ class TestDarkMagic(object):
                       repr=True, cmp=True, hash=True, init=True),
         ) == attr.fields(PC)
 
-    def test_subclassing(self):
+    def test_subclassing_with_extra_attrs(self):
         """
-        Sub-classing does what you'd hope for.
+        Sub-classing (where the subclass has extra attrs) does what you'd hope
+        for.
         """
         obj = object()
         i = Sub(x=obj, y=2)
         assert i.x is i.meth() is obj
         assert i.y == 2
         assert "Sub(x={obj}, y=2)".format(obj=obj) == repr(i)
+
+    def test_subclass_without_extra_attrs(self):
+        """
+        Sub-classing (where the subclass does not have extra attrs) still
+        behaves the same as a subclss with extra attrs.
+        """
+        class Sub2(Super):
+            pass
+
+        obj = object()
+        i = Sub2(x=obj)
+        assert i.x is i.meth() is obj
+        assert "Sub2(x={obj})".format(obj=obj) == repr(i)


### PR DESCRIPTION
Currently, if you subclass an `@attr.s`-decorated class without re-decorating with another `@attr.s`, the `repr` displays the name of the superclass, not the subclass.