### PR TITLE
Allow the case of initializing attributes that are set to `init=False`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changes:
 
 - Allow the case of initializing attributes that are set to `init=False`.
   This allows for clean initializer parameter lists while being able to initialize attributes to default values.
+  `[32] <https://github.com/hynek/attrs/issues/32>`_
 
 
 15.2.0 (2015-12-08)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Allow the case of initializing attributes that are set to `init=False`.
+  This allows for clean initializer parameter lists while being able to initialize attributes to default values.
 
 
 15.2.0 (2015-12-08)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -71,6 +71,20 @@ For private attributes, ``attrs`` will strip the leading underscores for keyword
    >>> C(x=1)
    C(_x=1)
 
+If you want to initialize your private attributes yourself, you can do that too:
+
+.. doctest::
+
+   >>> @attr.s
+   ... class C(object):
+   ...     _x = attr.ib(init=False, default=42)
+   >>> C()
+   C(_x=42)
+   >>> C(23)
+   Traceback (most recent call last):
+      ...
+   TypeError: __init__() takes exactly 1 argument (2 given)
+
 An additional way (not unlike ``characteristic``) of defining attributes is supported too.
 This is useful in times when you want to enhance classes that are not yours (nice ``__repr__`` for Django models anyone?):
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -52,10 +52,10 @@ def attr(default=NOTHING, validator=None,
         :func:`attr.s`!
 
     :param default: Value that is used if an ``attrs``-generated
-        ``__init__`` is used and no value is passed while instantiating.  If
-        the value an instance of :class:`Factory`, it callable will be use to
-        construct a new value (useful for mutable datatypes like lists or
-        dicts).
+        ``__init__`` is used and no value is passed while instantiating or the
+        attribute is excluded using ``init=False``.  If the value an instance
+        of :class:`Factory`, it callable will be use to construct a new value
+        (useful for mutable datatypes like lists or dicts).
     :type default: Any value.
 
     :param callable validator: :func:`callable` that is called by
@@ -79,7 +79,9 @@ def attr(default=NOTHING, validator=None,
         method.
 
     :param bool init: Include this attribute in the generated ``__init__``
-        method.
+        method.  It is possible to set this to ``False`` and set a default
+        value.  In that case this attributed is unconditionally initialized
+        with the specified default value or factory.
 
     :param callable convert: :func:`callable` that is called by
         ``attrs``-generated ``__init__`` methods to convert attribute's value

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -210,6 +210,24 @@ class TestAddInit(object):
             e.value.args[0]
         )
 
+    def test_no_init_default(self):
+        """
+        If `init` is False but a Factory is specified, don't allow passing that
+        argument but initialize it anyway.
+        """
+        C = make_class("C", {
+            "_a": attr(init=False, default=42),
+            "_b": attr(init=False, default=Factory(list)),
+            "c": attr()}
+        )
+        with pytest.raises(TypeError):
+            C(a=1, c=2)
+        with pytest.raises(TypeError):
+            C(b=1, c=2)
+
+        i = C(23)
+        assert (42, [], 23) == (i._a, i._b, i.c)
+
     def test_sets_attributes(self):
         """
         The attributes are initialized using the passed keywords.


### PR DESCRIPTION
This allows for clean initializer parameter lists while being able to
initialize attributes to default values.