### PR TITLE
ENH: bundle inspect.isclass to avoid paying the cost of inspect import.

### DIFF
--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -10,6 +10,8 @@ PY2 = sys.version_info[0] == 2
 if PY2:
     import types
 
+    # We 'bundle' isclass instead of using inspect as importing inspect is
+    # fairly expensive (order of 10-15 ms for a modern machine in 2016)
     def isclass(klass):
         return isinstance(klass, (type, types.ClassType))
 

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -8,6 +8,11 @@ PY2 = sys.version_info[0] == 2
 
 
 if PY2:
+    import types
+
+    def isclass(klass):
+        return isinstance(klass, (type, types.ClassType))
+
     # TYPE is used in exceptions, repr(int) is different on Python 2 and 3.
     TYPE = "type"
 
@@ -20,6 +25,9 @@ if PY2:
     def iterkeys(d):
         return d.iterkeys()
 else:
+    def isclass(klass):
+        return isinstance(klass, type)
+
     TYPE = "class"
 
     def exec_(code, locals_, globals_):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -2,10 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import copy
 import hashlib
-import inspect
 import linecache
 
-from ._compat import exec_, iteritems, iterkeys
+from ._compat import exec_, iteritems, isclass, iterkeys
 from . import _config
 
 
@@ -411,7 +410,7 @@ def fields(cl):
 
     :rtype: tuple of :class:`attr.Attribute`
     """
-    if not inspect.isclass(cl):
+    if not isclass(cl):
         raise TypeError("Passed object must be a class.")
     attrs = getattr(cl, "__attrs_attrs__", None)
     if attrs is None:

--- a/src/attr/filters.py
+++ b/src/attr/filters.py
@@ -4,8 +4,7 @@ Commonly useful filters for :func:`attr.asdict`.
 
 from __future__ import absolute_import, division, print_function
 
-import inspect
-
+from ._compat import isclass
 from ._make import Attribute
 
 
@@ -14,7 +13,7 @@ def _split_what(what):
     Returns a tuple of `frozenset`s of classes and attributes.
     """
     return (
-        frozenset(cl for cl in what if inspect.isclass(cl)),
+        frozenset(cl for cl in what if isclass(cl)),
         frozenset(cl for cl in what if isinstance(cl, Attribute)),
     )
 


### PR DESCRIPTION
Importing `attrs` on my fairly decent machine takes around 20-30 ms. Since I am using `attrs` in CLI tools, every small bit counts, and I'd like to make `import attrs` faster.

`inspect` is known as an expensive module to import, and since we use it only for one trivial oneline method, would it be acceptable to remove `inspect` import ? That makes importing `attrs` more or less free on my machine.