### PR TITLE
asdict - propagate dict_factory properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - python: "3.5"
       env: TOXENV=py35
     - python: "pypy"
-      env: TOXENV=pypy
+      env: TOXENV=pypy HYPOTHESIS_PROFILE=travis_pypy
 
     # Meta
     - python: "3.5"

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
+import os
 
 import pytest
+from hypothesis import settings
 
 
 @pytest.fixture(scope="session")
@@ -17,3 +19,7 @@ def C():
         y = attr()
 
     return C
+
+# PyPy on Travis appears to be too slow.
+settings.register_profile("travis_pypy", settings(perform_health_check=False))
+settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'default'))

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -38,17 +38,21 @@ def asdict(inst, recurse=True, filter=None, dict_factory=dict):
             continue
         if recurse is True:
             if has(v.__class__):
-                rv[a.name] = asdict(v, recurse=True, filter=filter)
+                rv[a.name] = asdict(v, recurse=True, filter=filter,
+                                    dict_factory=dict_factory)
             elif isinstance(v, (tuple, list, set)):
                 rv[a.name] = [
-                    asdict(i, recurse=True, filter=filter)
+                    asdict(i, recurse=True, filter=filter,
+                           dict_factory=dict_factory)
                     if has(i.__class__) else i
                     for i in v
                 ]
             elif isinstance(v, dict):
-                rv[a.name] = dict((asdict(kk) if has(kk.__class__) else kk,
-                                   asdict(vv) if has(vv.__class__) else vv)
-                                  for kk, vv in iteritems(v))
+                df = dict_factory
+                rv[a.name] = df((
+                    asdict(kk, dict_factory=df) if has(kk.__class__) else kk,
+                    asdict(vv, dict_factory=df) if has(vv.__class__) else vv)
+                    for kk, vv in iteritems(v))
             else:
                 rv[a.name] = v
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import keyword
 import string
 
 from hypothesis import strategies as st
@@ -51,13 +52,18 @@ def _gen_attr_names():
     """
     Generate names for attributes, 'a'...'z', then 'aa'...'zz'.
 
-    702 different attribute names should be enough in practice.
+    ~702 different attribute names should be enough in practice.
+
+    Some short strings (such as 'as') are keywords, so we skip them.
     """
     lc = string.ascii_lowercase
     for c in lc:
         yield c
     for outer in lc:
         for inner in lc:
+            res = outer + inner
+            if keyword.iskeyword(res):
+                continue
             yield outer + inner
 
 
@@ -67,11 +73,51 @@ def _create_hyp_class(attrs):
     """
     return make_class('HypClass', dict(zip(_gen_attr_names(), attrs)))
 
+
+def _create_hyp_nested_strategy(simple_class_strategy):
+    """
+    Create a recursive attrs class.
+
+    Given a strategy for building (simpler) classes, create and return
+    a strategy for building classes that have the simpler class as an
+    attribute.
+    """
+    # Use a tuple strategy to combine simple attributes and an attr class.
+    def just_class(tup):
+        combined_attrs = list(tup[0])
+        combined_attrs.append(attr.ib(default=attr.Factory(tup[1])))
+        return _create_hyp_class(combined_attrs)
+
+    def list_of_class(tup):
+        default = attr.Factory(lambda: [tup[1]()])
+        combined_attrs = list(tup[0])
+        combined_attrs.append(attr.ib(default=default))
+        return _create_hyp_class(combined_attrs)
+
+    def dict_of_class(tup):
+        default = attr.Factory(lambda: {"cls": tup[1]()})
+        combined_attrs = list(tup[0])
+        combined_attrs.append(attr.ib(default=default))
+        return _create_hyp_class(combined_attrs)
+
+    return st.one_of(st.tuples(st.lists(simple_attrs), simple_class_strategy)
+                     .map(just_class),
+                     st.tuples(st.lists(simple_attrs), simple_class_strategy)
+                     .map(list_of_class))
+
 bare_attrs = st.just(attr.ib(default=None))
 int_attrs = st.integers().map(lambda i: attr.ib(default=i))
 str_attrs = st.text().map(lambda s: attr.ib(default=s))
 float_attrs = st.floats().map(lambda f: attr.ib(default=f))
+dict_attrs = (st.dictionaries(keys=st.text(), values=st.integers())
+              .map(lambda d: attr.ib(default=d)))
 
-simple_attrs = st.one_of(bare_attrs, int_attrs, str_attrs, float_attrs)
+simple_attrs = st.one_of(bare_attrs, int_attrs, str_attrs, float_attrs,
+                         dict_attrs)
 
 simple_classes = st.lists(simple_attrs).map(_create_hyp_class)
+
+# Ok, so st.recursive works by taking a base strategy (in this case,
+# simple_classes) and a special function. This function receives a strategy,
+# and returns another strategy (building on top of the base strategy).
+nested_classes = st.recursive(simple_classes, _create_hyp_nested_strategy)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = coverage-clean,py27,py34,py35,pypy,flake8,manifest,docs,readme,coverag
 
 [testenv]
 deps = -rdev-requirements.txt
-commands = coverage run --parallel -m pytest -s {posargs}
+commands = coverage run --parallel -m pytest {posargs}
 passenv = HYPOTHESIS_PROFILE
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = coverage-clean,py27,py34,py35,pypy,flake8,manifest,docs,readme,coverag
 
 [testenv]
 deps = -rdev-requirements.txt
-commands = coverage run --parallel -m pytest {posargs}
+commands = coverage run --parallel -m pytest -s {posargs}
+passenv = HYPOTHESIS_PROFILE
 
 
 [testenv:flake8]


### PR DESCRIPTION
So yeah, I made a dumb mistake when adding support for `dict_factory` - I forgot to ensure the factory propagates further than the initial class - to attributes containing dicts, lists and other instances of `attrs` classes. It came up instantly at work when we upgraded to actually use the feature :) My bad.

I'm pretty sure the `dict_factory` argument should propagate - one of the use cases is to use an OrderedDict to preserve order, and that's just not going to happen if ordinary dicts are used anywhere in the conversion.

The fix is simple, just propagate the argument in `asdict`.

Since the original tests didn't catch this, I've worked on expanding our Hypothesis strategies. (More challenging than just the fix :) In addition to the `simple_classes` strategy, there is also now a `nested_classes` strategy. `nested_classes` will generate `attrs` classes just like `simple_classes`, but attributes may also contain the following default values:
* instances of other `nested_classes` `attrs` classes
* lists, containing a single element pulled from `nested_classes`
* dicts, containing a key "cls" pointing to a class pulled from `nested_classes`

These cases should cover all cases in `asdict`. There's a new test, `test_recurse_property`, which asserts that for any `nested_classes` class, all dicts produced by `asdict` are of the appropriate class.