### PR TITLE
Simplify asdict and has.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changes:
 
 - ``attr.asdict``\ 's ``dict_factory`` arguments is now propagated on recursion.
   `#45 <https://github.com/hynek/attrs/issues/45>`_
+- ``attr.asdict`` and ``attr.has`` are significantly faster.
+  `#48 <https://github.com/hynek/attrs/issues/48>`_
 
 
 ----

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -71,7 +71,7 @@ def has(cl):
 
     :rtype: :class:`bool`
     """
-    return hasattr(cl, "__attrs_attrs__")
+    return getattr(cl, "__attrs_attrs__", None) is not None
 
 
 def assoc(inst, **changes):

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import copy
 
 from ._compat import iteritems
-from ._make import Attribute, NOTHING, fields
+from ._make import Attribute, NOTHING, _fast_attrs_iterate
 
 
 def asdict(inst, recurse=True, filter=None, dict_factory=dict):
@@ -30,7 +30,7 @@ def asdict(inst, recurse=True, filter=None, dict_factory=dict):
     .. versionadded:: 16.0.0
         *dict_factory*
     """
-    attrs = fields(inst.__class__)
+    attrs = _fast_attrs_iterate(inst)
     rv = dict_factory()
     for a in attrs:
         v = getattr(inst, a.name)
@@ -71,12 +71,7 @@ def has(cl):
 
     :rtype: :class:`bool`
     """
-    try:
-        fields(cl)
-    except ValueError:
-        return False
-    else:
-        return True
+    return hasattr(cl, "__attrs_attrs__")
 
 
 def assoc(inst, **changes):

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -15,12 +15,12 @@ from . import simple_classes, nested_classes
 from attr._funcs import (
     asdict,
     assoc,
-    fields,
     has,
 )
 from attr._make import (
     attr,
     attributes,
+    fields,
 )
 
 MAPPING_TYPES = (dict, OrderedDict)


### PR DESCRIPTION
So, as you might have noticed, I'm totally a fan of this library :) Also, we've been using it at work a lot lately, and it's really working out for us. So I thought I might see if anything can be optimized a little.

We use `asdict` a lot. I actually totally love the way attrs interacts with data contained in Python primitives, like dicts and lists. At a later date I might submit some converters that make these transformations really easy. However, now I was taking a look at `asdict` performance, to see if it can be optimized.

Actually my first instinct was to see if I can use Cython to speed things up, mostly because I wanted to learn Cython a little more. The changes I'm submitting now have a far greater effect than using Cython though, so I'm not sure Cython's worth it. Maybe later?

Anyway, on to measuring. I'm using the `perf` library as a more reliable, fancy timeit. (Newest version: `pip install git+https://github.com/haypo/perf.git#egg=perf`) We actually have a way of generating attrs classes, in tests: the nested_classes Hypothesis strategy. We can use a pre-seeded Random instance to make it reproducible.

For example, seeding with the number 1, pre-changes:
```
> pyperf timeit -g -s "from attr import asdict; from random import Random; from tests import nested_classes; r = Random(1); C = nested_classes.example(r); c=C()" "asdict(c)"
....................
499 us: 2 ##########################
500 us: 1 #############
502 us: 1 #############
503 us: 0 |
504 us: 1 #############
506 us: 4 #####################################################
507 us: 3 ########################################
508 us: 5 ##################################################################
510 us: 5 ##################################################################
511 us: 4 #####################################################
512 us: 6 ###############################################################################
514 us: 6 ###############################################################################
515 us: 5 ##################################################################
516 us: 6 ###############################################################################
518 us: 1 #############
519 us: 2 ##########################
521 us: 2 ##########################
522 us: 0 |
523 us: 2 ##########################
525 us: 2 ##########################
526 us: 2 ##########################

Median +- std dev: 513 us +- 6 us
```


Post changes:
```
> pyperf timeit -g -s "from attr import asdict; from random import Random; from tests import nested_classes; r = Random(1); C = nested_classes.example(r); c=C()" "asdict(c)"
....................
20.6 us: 2 ##################
20.7 us: 2 ##################
20.8 us: 4 ###################################
20.9 us: 5 ############################################
21.0 us: 5 ############################################
21.1 us: 8 ######################################################################
21.2 us: 3 ##########################
21.3 us: 2 ##################
21.4 us: 6 #####################################################
21.5 us: 3 ##########################
21.7 us: 9 ###############################################################################
21.8 us: 4 ###################################
21.9 us: 1 #########
22.0 us: 0 |
22.1 us: 2 ##################
22.2 us: 2 ##################
22.3 us: 0 |
22.4 us: 0 |
22.5 us: 1 #########
22.6 us: 0 |
22.7 us: 1 #########

Median +- std dev: 21.4 us +- 0.4 us
```

So that's a change of 513 us to  21.4 us. We can get more examples by seeding the Random instance with other numbers. Seeding with 2 will produce a larger class, and the difference will be 1.74 ms +- 0.03 ms to 72.9 us +- 1.4 us.

I think you'll find the changes are reasonable. :)