### PR TITLE
Make copyright reproducible.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 # serve to show the default.
 
 import codecs
-import datetime
 import os
 import re
 
@@ -80,10 +79,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'attrs'
-year = datetime.date.today().year
-copyright = u'2015{0}, Hynek Schlawack'.format(
-    u'-{0}'.format(year) if year != 2015 else u""
-)
+copyright = u'2015, Hynek Schlawack'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This patch allows for [reproducible builds of attrs](https://bugs.debian.org/833886).

An alternative to all this skullduggery is to make the copyright year a static "2015". According to my understanding of the Berne Convention et al, the "first year of publication" is what you should list, so I think that would be fine?