### PR TITLE
Make Attribute instances immutable and slotted.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,8 +25,9 @@ Changes:
 
 - ``attr.asdict``\ 's ``dict_factory`` arguments is now propagated on recursion.
   `#45 <https://github.com/hynek/attrs/issues/45>`_
-- ``attr.asdict`` and ``attr.has`` are significantly faster.
+- ``attr.asdict``, ``attr.has`` and ``attr.fields`` are significantly faster.
   `#48 <https://github.com/hynek/attrs/issues/48>`_
+  `#51 <https://github.com/hynek/attrs/issues/51>`_
 
 
 ----

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import copy
 
 from ._compat import iteritems
-from ._make import Attribute, NOTHING, _fast_attrs_iterate
+from ._make import Attribute, NOTHING, fields
 
 
 def asdict(inst, recurse=True, filter=None, dict_factory=dict):
@@ -30,7 +30,7 @@ def asdict(inst, recurse=True, filter=None, dict_factory=dict):
     .. versionadded:: 16.0.0
         *dict_factory*
     """
-    attrs = _fast_attrs_iterate(inst)
+    attrs = fields(inst.__class__)
     rv = dict_factory()
     for a in attrs:
         v = getattr(inst, a.name)

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -443,7 +443,7 @@ def _convert(inst):
 
     :param inst: Instance of a class with ``attrs`` attributes.
     """
-    for a in fields(inst.__class__):
+    for a in inst.__class__.__attrs_attrs__:
         if a.convert is not None:
             setattr(inst, a.name, a.convert(getattr(inst, a.name)))
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -419,15 +419,6 @@ def fields(cl):
     return attrs
 
 
-def _fast_attrs_iterate(inst):
-    """
-    Fast internal iteration over the attr descriptors.
-
-    Using fields to iterate is slow because it involves deepcopy.
-    """
-    return inst.__class__.__attrs_attrs__
-
-
 def validate(inst):
     """
     Validate all attributes on *inst* that have a validator.
@@ -439,7 +430,7 @@ def validate(inst):
     if _config._run_validators is False:
         return
 
-    for a in _fast_attrs_iterate(inst):
+    for a in fields(inst.__class__):
         if a.validator is not None:
             a.validator(inst, a, getattr(inst, a.name))
 
@@ -452,7 +443,7 @@ def _convert(inst):
 
     :param inst: Instance of a class with ``attrs`` attributes.
     """
-    for a in _fast_attrs_iterate(inst):
+    for a in fields(inst.__class__):
         if a.convert is not None:
             setattr(inst, a.name, a.convert(getattr(inst, a.name)))
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 from hypothesis import given
-from hypothesis.strategies import booleans
+from hypothesis.strategies import booleans, sampled_from
 
-from . import simple_attr
+from . import simple_attr, simple_attrs
 from attr import _config
 from attr._compat import PY3
 from attr._make import (
@@ -22,6 +22,8 @@ from attr._make import (
     make_class,
     validate,
 )
+
+attrs = simple_attrs.map(lambda c: Attribute.from_counting_attr('name', c))
 
 
 class TestCountingAttr(object):
@@ -183,6 +185,14 @@ class TestAttributes(object):
             pass
         assert "C3()" == repr(C3())
         assert C3() == C3()
+
+    @given(attr=attrs, attr_name=sampled_from(Attribute.__slots__))
+    def test_immutable(self, attr, attr_name):
+        """
+        Attribute instances are immutable.
+        """
+        with pytest.raises(AttributeError):
+            setattr(attr, attr_name, 1)
 
     @pytest.mark.parametrize("method_name", [
         "__repr__",
@@ -385,15 +395,6 @@ class TestFields(object):
         Returns a list of `Attribute`a.
         """
         assert all(isinstance(a, Attribute) for a in fields(C))
-
-    def test_copies(self, C):
-        """
-        Returns a new list object with new `Attribute` objects.
-        """
-        assert C.__attrs_attrs__ is not fields(C)
-        assert all(new == original and new is not original
-                   for new, original
-                   in zip(fields(C), C.__attrs_attrs__))
 
 
 class TestConvert(object):


### PR DESCRIPTION
If this looks good to you, I'll add something to the changelog. Since the docs already define Attributes are read-only, this should be backwards compatible.