### PR TITLE
Doc typo fixes

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -4,7 +4,7 @@ Contributor Covenant Code of Conduct
 Our Pledge
 ----------
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 Our Standards
 -------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,18 +1,18 @@
 How To Contribute
 =================
 
-Every open source project lives from the generous help by contributors that sacrifice their time and ``attrs`` is no different.
+Every open source project lives due to generous help by contributors sacrificing their time; ``attrs`` is no different.
 
 Here are a few guidelines to get you started:
 
 - Try to limit each pull request to one change only.
 - To run the test suite, all you need is a recent tox_.
   It will ensure the test suite runs with all dependencies against all Python versions just as it will on `Travis CI`_.
-  If you lack some Python version, you can can always limit the environments like ``tox -e py27,py35`` (in that case you may want to look into pyenv_ that makes it very easy to install many different Python versions in parallel).
+  If you lack some Python versions, you can can always limit the environments like ``tox -e py27,py35`` (in that case you may want to look into pyenv_, which makes it very easy to install many different Python versions in parallel).
 - Make sure your changes pass our CI.
   You won't get any feedback until it's green unless you ask for it.
 - If your change is noteworthy, add an entry to the changelog_.
-  Use present tense, semantic newlines, and add link to your pull request.
+  Use present tense, semantic newlines, and add a link to your pull request.
 - No contribution is too small; please submit as many fixes for typos and grammar bloopers as you can!
 - Don’t break `backward compatibility`_.
 - *Always* add tests and docs for your code.
@@ -20,13 +20,13 @@ Here are a few guidelines to get you started:
 - Write `good test docstrings`_.
 - Obey `PEP 8`_ and `PEP 257`_.
 - If you address review feedback, make sure to bump the pull request.
-  Maintainers don’t receive notifications if you push new commits.
+  Maintainers don’t receive notifications when you push new commits.
 
 Please note that this project is released with a Contributor `Code of Conduct`_.
 By participating in this project you agree to abide by its terms.
 Please report any harm to `Hynek Schlawack`_ in any way you find appropriate.
 
-Thank you for considering to contribute to ``attrs``!
+Thank you for considering contributing to ``attrs``!
 
 
 .. _`Hynek Schlawack`: https://hynek.me/about/

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ You just specify the attributes to work with and ``attrs`` gives you:
 
 This gives you the power to use actual classes with actual types in your code instead of confusing ``tuple``\ s or confusingly behaving ``namedtuple``\ s.
 
-So put down that type-less data structures and welcome some class into your life!
+So put down those type-less data structures and welcome some class into your life!
 
-``attrs``\ ’s documentation lives at `Read the Docs <https://attrs.readthedocs.io/>`_, the code on `GitHub <https://github.com/hynek/attrs>`_.
+``attrs``\ ’s documentation lives at `Read the Docs <https://attrs.readthedocs.io/>`_, and the code on `GitHub <https://github.com/hynek/attrs>`_.
 It’s rigorously tested on Python 2.7, 3.4+, and PyPy.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -105,7 +105,7 @@ Core
 Helpers
 -------
 
-``attrs`` comes with a bunch of helper methods that make the work with it easier:
+``attrs`` comes with a bunch of helper methods that make working with it easier:
 
 .. autofunction:: attr.fields
 
@@ -150,7 +150,7 @@ Helpers
       {'y': {'y': 3, 'x': 2}, 'x': 1}
 
 
-``attrs`` comes with some handy helpers for filtering:
+``attrs`` includes some handy helpers for filtering:
 
 .. autofunction:: attr.filters.include
 
@@ -206,7 +206,7 @@ Validators can be globally disabled if you want to run them only in development 
 Validators
 ----------
 
-``attrs`` comes with some common validators within the ``attrs.validators`` module:
+``attrs`` comes with some common validators in the ``attrs.validators`` module:
 
 
 .. autofunction:: attr.validators.instance_of

--- a/docs/backward-compatibility.rst
+++ b/docs/backward-compatibility.rst
@@ -3,17 +3,17 @@ Backward Compatibility
 
 .. currentmodule:: attr
 
-``attrs`` has a very strong backward compatibility policy that is inspired by the one of the `Twisted framework <https://twistedmatrix.com/trac/wiki/CompatibilityPolicy>`_.
+``attrs`` has a very strong backward compatibility policy that is inspired by the policy of the `Twisted framework <https://twistedmatrix.com/trac/wiki/CompatibilityPolicy>`_.
 
-Put simply, you shouldn't ever be afraid to upgrade ``attrs`` if you're using its public APIs.
-If there will ever be need to break compatibility, it will be announced in the :doc:`changelog`, raise deprecation warning for a year (if possible) before it's finally really broken.
+Put simply, you shouldn't ever be afraid to upgrade ``attrs`` if you're only using its public APIs.
+If there will ever be a need to break compatibility, it will be announced in the :doc:`changelog` and raise a ``DeprecationWarning`` for a year (if possible) before it's finally really broken.
 
 
 .. _exemption:
 
 .. warning::
 
-   The structure of the :class:`attr.Attribute` class is exempted from this rule.
-   It *will* change in the future but since it should be considered read-only, that shouldn't matter.
+   The structure of the :class:`attr.Attribute` class is exempt from this rule.
+   It *will* change in the future, but since it should be considered read-only, that shouldn't matter.
 
    However if you intend to build extensions on top of ``attrs`` you have to anticipate that.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -22,7 +22,7 @@ The simplest possible usage would be:
    >>> Empty() is Empty()
    False
 
-So in other words: ``attrs`` useful even without actual attributes!
+So in other words -- ``attrs``: useful even without actual attributes!
 
 But you'll usually want some data on your classes, so let's add some:
 
@@ -33,7 +33,7 @@ But you'll usually want some data on your classes, so let's add some:
    ...     x = attr.ib()
    ...     y = attr.ib()
 
-These by default, all features are added, so you have immediately a fully functional data class with a nice ``repr`` string and comparison methods.
+By default, all features are added, so you immediately have a fully functional data class with a nice ``repr`` string and comparison methods.
 
 .. doctest::
 
@@ -46,7 +46,7 @@ These by default, all features are added, so you have immediately a fully functi
    >>> c1 == c2
    False
 
-As shown, the generated ``__init__`` method allows both for positional and keyword arguments.
+As shown, the generated ``__init__`` method allows for both positional and keyword arguments.
 
 If playful naming turns you off, ``attrs`` comes with no-nonsense aliases:
 
@@ -156,7 +156,7 @@ Therefore ``@attr.s`` comes with the ``repr_ns`` option to set it manually:
    C.D()
 
 ``repr_ns`` works on both Python 2 and 3.
-On Python 3 is overrides the implicit detection.
+On Python 3 it overrides the implicit detection.
 
 
 Converting to Dictionaries
@@ -256,7 +256,7 @@ More information on why class methods for constructing objects are awesome can b
 Validators
 ----------
 
-Although your initializers should be as dumb as possible, it can come handy to do some kind of validation on the arguments.
+Although your initializers should be as dumb as possible, it can come in handy to do some kind of validation on the arguments.
 That's when :func:`attr.ib`\ ’s ``validator`` argument comes into play.
 A validator is simply a callable that takes three arguments:
 
@@ -283,7 +283,7 @@ Since the validator runs *after* the instance is initialized, you can refer to o
       ...
    ValueError: 'x' has to be smaller than 'y'!
 
-``attrs`` won't intercept your changes to those attributes but you can always call :func:`attr.validate` on any instance to verify, that it's still valid:
+``attrs`` won't intercept your changes to those attributes but you can always call :func:`attr.validate` on any instance to verify that it's still valid:
 
 .. doctest::
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -54,7 +54,7 @@ Adding an attribute to a class concerns only those who actually care about that 
 …namedtuples?
 -------------
 
-The difference between :func:`collections.namedtuple`\ s and classes decorated by ``attrs`` is that the latter are type-sensitive and less typing aside regular classes:
+The difference between :func:`collections.namedtuple`\ s and classes decorated by ``attrs`` is that the latter are type-sensitive and require less typing as compared with regular classes:
 
 
 .. doctest::
@@ -78,7 +78,7 @@ The difference between :func:`collections.namedtuple`\ s and classes decorated b
    1
 
 
-…while namedtuple’s purpose is *explicitly* to behave like tuples:
+…while a namedtuple is *explicitly* intended to behave like a tuple:
 
 
 .. doctest::
@@ -94,7 +94,7 @@ The difference between :func:`collections.namedtuple`\ s and classes decorated b
 
 This can easily lead to surprising and unintended behaviors.
 
-Other than that, ``attrs`` also adds nifty features like validators or default values.
+Other than that, ``attrs`` also adds nifty features like validators and default values.
 
 .. _tuple: https://docs.python.org/2/tutorial/datastructures.html#tuples-and-sequences
 


### PR DESCRIPTION
Thanks for making this library, and for explicitly requesting typo-fixing PRs.

I heard about it from https://lwn.net/Articles/697146

If you'd prefer, I can squash these commits into one; the only reason they are separate is due to GitHub's in-browser editor.