### PR TITLE
[RFC] Implement immutability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,8 @@ Changes:
   `#48 <https://github.com/hynek/attrs/issues/48>`_
   `#51 <https://github.com/hynek/attrs/issues/51>`_
 - Add ``attr.attrs`` and ``attr.attrib`` as a more consistent aliases for ``attr.s`` and ``attr.ib``.
+- Add ``frozen`` option to ``attr.s`` that will make instances best-effort immutable.
+  `#60 <https://github.com/hynek/attrs/issues/60>`_
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,7 +18,7 @@ What follows is the API explanation, if you'd like a more hands-on introduction,
 Core
 ----
 
-.. autofunction:: attr.s(these=None, repr_ns=None, repr=True, cmp=True, hash=True, init=True, slots=False)
+.. autofunction:: attr.s(these=None, repr_ns=None, repr=True, cmp=True, hash=True, init=True, slots=False, frozen=False)
 
    .. note::
 
@@ -100,6 +100,9 @@ Core
       ...     x = attr.ib(default=attr.Factory(list))
       >>> C()
       C(x=[])
+
+
+.. autoexception:: attr.exceptions.FrozenInstanceError
 
 
 Helpers

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -466,6 +466,21 @@ I guess that means Clojure can be shut down now, sorry Rich!
    >>> i1 == i2
    False
 
+If you're still not convinced, that Python + ``attrs`` is the better Clojure, maybe immutable classes can change your mind:
+
+.. doctest::
+
+   >>> @attr.s(frozen=True)
+   ... class C(object):
+   ...     x = attr.ib()
+   >>> i = C(1)
+   >>> i.x = 2
+   Traceback (most recent call last):
+      ...
+   attr.exceptions.FrozenInstanceError: can't set attribute
+   >>> i.x
+   1
+
 Sometimes you may want to create a class programmatically.
 ``attrs`` won't let you down and gives you :func:`attr.make_class` :
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -466,7 +466,7 @@ I guess that means Clojure can be shut down now, sorry Rich!
    >>> i1 == i2
    False
 
-If you're still not convinced, that Python + ``attrs`` is the better Clojure, maybe immutable classes can change your mind:
+If you're still not convinced that Python + ``attrs`` is the better Clojure, maybe immutable-ish classes can change your mind:
 
 .. doctest::
 

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -19,6 +19,7 @@ from ._config import (
     get_run_validators,
     set_run_validators,
 )
+from . import exceptions
 from . import filters
 from . import validators
 
@@ -49,6 +50,7 @@ __all__ = [
     "attrib",
     "attributes",
     "attrs",
+    "exceptions",
     "fields",
     "filters",
     "get_run_validators",

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -150,7 +150,7 @@ def _frozen_setattrs(self, name, value):
     """
     Attached to frozen classes as __setattr__.
     """
-    raise FrozenInstanceError("can't set attribute")
+    raise FrozenInstanceError()
 
 
 def attributes(maybe_cls=None, these=None, repr_ns=None,
@@ -572,7 +572,7 @@ class Attribute(object):
                     raise TypeError("Missing argument '{arg}'.".format(arg=a))
 
     def __setattr__(self, name, value):
-        raise AttributeError("can't set attribute")  # To mirror namedtuple.
+        raise FrozenInstanceError()
 
     @classmethod
     def from_counting_attr(cls, name, ca):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -188,10 +188,18 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         memory-efficient.  See :ref:`slots` for further ramifications.
     :param bool frozen: Make instances immutable after initialization.  If
         someone attempts to modify a frozen instance,
-        :exc:`attr.exceptions.FrozenInstanceError` is raised.  Please note that
-        this is achieved by installing a custom ``__setattr__`` method on your
-        class so you can't implement an own one.  Please note also that true
-        immutability is impossible in Python.
+        :exc:`attr.exceptions.FrozenInstanceError` is raised.
+
+        Please note:
+
+            1. This is achieved by installing a custom ``__setattr__`` method
+               on your class so you can't implement an own one.
+
+            2. True immutability is impossible in Python.
+
+            3. This *does* have a minor a runtime performance impact when
+               initializing new instances.  In other words: ``__init__`` is
+               slightly slower with ``frozen=True``.
 
         ..  _slots: https://docs.python.org/3.5/reference/datamodel.html#slots
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, division, print_function
 import hashlib
 import linecache
 
-from ._compat import exec_, iteritems, isclass, iterkeys
 from . import _config
+from ._compat import exec_, iteritems, isclass, iterkeys
+from .exceptions import FrozenInstanceError
 
 
 class _Nothing(object):
@@ -145,8 +146,16 @@ def _transform_attrs(cls, these):
             had_default = True
 
 
+def _frozen_setattrs(self, name, value):
+    """
+    Attached to frozen classes as __setattr__.
+    """
+    raise FrozenInstanceError("can't set attribute")
+
+
 def attributes(maybe_cls=None, these=None, repr_ns=None,
-               repr=True, cmp=True, hash=True, init=True, slots=False):
+               repr=True, cmp=True, hash=True, init=True,
+               slots=False, frozen=False):
     """
     A class decorator that adds `dunder
     <https://wiki.python.org/moin/DunderAlias>`_\ -methods according to the
@@ -161,33 +170,33 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         If *these* is not `None`, the class body is *ignored*.
     :type these: :class:`dict` of :class:`str` to :func:`attr.ib`
 
-    :param repr_ns: When using nested classes, there's no way in Python 2 to
-        automatically detect that.  Therefore it's possible to set the
+    :param str repr_ns: When using nested classes, there's no way in Python 2
+        to automatically detect that.  Therefore it's possible to set the
         namespace explicitly for a more meaningful ``repr`` output.
-
-    :param repr: Create a ``__repr__`` method with a human readable
+    :param bool repr: Create a ``__repr__`` method with a human readable
         represantation of ``attrs`` attributes..
-    :type repr: bool
-
-    :param cmp: Create ``__eq__``, ``__ne__``, ``__lt__``, ``__le__``,
+    :param bool cmp: Create ``__eq__``, ``__ne__``, ``__lt__``, ``__le__``,
         ``__gt__``, and ``__ge__`` methods that compare the class as if it were
         a tuple of its ``attrs`` attributes.  But the attributes are *only*
         compared, if the type of both classes is *identical*!
-    :type cmp: bool
+    :param bool hash: Create a ``__hash__`` method that returns the
+        :func:`hash` of a tuple of all ``attrs`` attribute values.
+    :param bool init: Create a ``__init__`` method that initialiazes the
+        ``attrs`` attributes.  Leading underscores are stripped for the
+        argument name.
+    :param bool slots: Create a slots_-style class that's more
+        memory-efficient.  See :ref:`slots` for further ramifications.
+    :param bool frozen: Make instances immutable after initialization.  If
+        someone attempts to modify a frozen instance,
+        :exc:`attr.exceptions.FrozenInstanceError` is raised.  Please note that
+        this is achieved by installing a custom ``__setattr__`` method on your
+        class so you can't implement an own one.
 
-    :param hash: Create a ``__hash__`` method that returns the :func:`hash` of
-        a tuple of all ``attrs`` attribute values.
-    :type hash: bool
+        ..  _slots: https://docs.python.org/3.5/reference/datamodel.html#slots
 
-    :param init: Create a ``__init__`` method that initialiazes the ``attrs``
-        attributes.  Leading underscores are stripped for the argument name.
-    :type init: bool
+        ..  versionadded:: 16.0.0 *slots*
 
-    :param slots: Create a slots_-style class that's more memory-efficient.
-        See :ref:`slots` for further ramifications.
-    :type slots: bool
-
-    .. _slots: https://docs.python.org/3.5/reference/datamodel.html#slots
+        ..  versionadded:: 16.1.0 *frozen*
     """
     def wrap(cls):
         if getattr(cls, "__class__", None) is None:
@@ -209,8 +218,10 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         if hash is True:
             cls = _add_hash(cls)
         if init is True:
-            cls = _add_init(cls)
-        if slots:
+            cls = _add_init(cls, frozen)
+        if frozen is True:
+            cls.__setattr__ = _frozen_setattrs
+        if slots is True:
             cls_dict = dict(cls.__dict__)
             cls_dict["__slots__"] = tuple(ca_list)
             for ca_name in ca_list:
@@ -367,7 +378,10 @@ def _add_repr(cls, ns=None, attrs=None):
     return cls
 
 
-def _add_init(cls):
+def _add_init(cls, frozen):
+    """
+    Add a __init__ method to *cls*.  If *frozen* is True, make it immutable.
+    """
     attrs = [a for a in cls.__attrs_attrs__
              if a.init or a.default is not NOTHING]
 
@@ -378,7 +392,7 @@ def _add_init(cls):
         sha1.hexdigest()
     )
 
-    script = _attrs_to_script(attrs)
+    script = _attrs_to_script(attrs, frozen)
     locs = {}
     bytecode = compile(script, unique_filename, "exec")
     attr_dict = dict((a.name, a) for a in attrs)
@@ -450,10 +464,26 @@ def _convert(inst):
             setattr(inst, a.name, a.convert(getattr(inst, a.name)))
 
 
-def _attrs_to_script(attrs):
+def _attrs_to_script(attrs, frozen):
     """
     Return a valid Python script of an initializer for *attrs*.
+
+    If *frozen* is True, we cannot set the attributes directly so we use
+    ``object.__setattr__``.
     """
+    if frozen is True:
+        def fmt_setter(attr_name, value):
+            return "object.__setattr__(self, '%(attr_name)s', %(value)s)" % {
+                "attr_name": attr_name,
+                "value": value,
+            }
+    else:
+        def fmt_setter(attr_name, value):
+            return "self.%(attr_name)s = %(value)s" % {
+                "attr_name": attr_name,
+                "value": value,
+            }
+
     lines = []
     args = []
     has_validator = False
@@ -467,14 +497,16 @@ def _attrs_to_script(attrs):
         arg_name = a.name.lstrip("_")
         if a.init is False:
             if isinstance(a.default, Factory):
-                lines.append("""\
-self.{attr_name} = attr_dict["{attr_name}"].default.factory()""".format(
-                    attr_name=attr_name,
+                lines.append(fmt_setter(
+                    attr_name,
+                    "attr_dict['{attr_name}'].default.factory()"
+                    .format(attr_name=attr_name)
                 ))
             else:
-                lines.append("""\
-self.{attr_name} = attr_dict["{attr_name}"].default""".format(
-                    attr_name=attr_name,
+                lines.append(fmt_setter(
+                    attr_name,
+                    "attr_dict['{attr_name}'].default"
+                    .format(attr_name=attr_name)
                 ))
         elif a.default is not NOTHING and not isinstance(a.default, Factory):
             args.append(
@@ -483,26 +515,21 @@ self.{attr_name} = attr_dict["{attr_name}"].default""".format(
                     attr_name=attr_name,
                 )
             )
-            lines.append("self.{attr_name} = {arg_name}".format(
-                arg_name=arg_name,
-                attr_name=attr_name,
-            ))
+            lines.append(fmt_setter(attr_name, arg_name))
         elif a.default is not NOTHING and isinstance(a.default, Factory):
             args.append("{arg_name}=NOTHING".format(arg_name=arg_name))
-            lines.extend("""\
-if {arg_name} is not NOTHING:
-    self.{attr_name} = {arg_name}
-else:
-    self.{attr_name} = attr_dict["{attr_name}"].default.factory()"""
-                         .format(attr_name=attr_name,
-                                 arg_name=arg_name)
-                         .split("\n"))
+            lines.append("if {arg_name} is not NOTHING:"
+                         .format(arg_name=arg_name))
+            lines.append("    " + fmt_setter(attr_name, arg_name))
+            lines.append("else:")
+            lines.append("    " + fmt_setter(
+                attr_name,
+                "attr_dict['{attr_name}'].default.factory()"
+                .format(attr_name=attr_name)
+            ))
         else:
             args.append(arg_name)
-            lines.append("self.{attr_name} = {arg_name}".format(
-                attr_name=attr_name,
-                arg_name=arg_name,
-            ))
+            lines.append(fmt_setter(attr_name, arg_name))
 
     if has_convert:
         lines.append("_convert(self)")
@@ -511,10 +538,10 @@ else:
 
     return """\
 def __init__(self, {args}):
-    {setters}
+    {lines}
 """.format(
         args=", ".join(args),
-        setters="\n    ".join(lines) if lines else "pass",
+        lines="\n    ".join(lines) if lines else "pass",
     )
 
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -190,7 +190,8 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         someone attempts to modify a frozen instance,
         :exc:`attr.exceptions.FrozenInstanceError` is raised.  Please note that
         this is achieved by installing a custom ``__setattr__`` method on your
-        class so you can't implement an own one.
+        class so you can't implement an own one.  Please note also that true
+        immutability is impossible in Python.
 
         ..  _slots: https://docs.python.org/3.5/reference/datamodel.html#slots
 

--- a/src/attr/exceptions.py
+++ b/src/attr/exceptions.py
@@ -4,4 +4,9 @@ from __future__ import absolute_import, division, print_function
 class FrozenInstanceError(AttributeError):
     """
     A frozen/immutable instance has been attempted to be modified.
+
+    It mirrors the behavior of ``namedtuples`` by using the same error message
+    and subclassing :exc:`AttributeError``.
     """
+    msg = "can't set attribute"
+    args = [msg]

--- a/src/attr/exceptions.py
+++ b/src/attr/exceptions.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
+
+class FrozenInstanceError(AttributeError):
+    """
+    A frozen/immutable instance has been attempted to be modified.
+    """

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -35,7 +35,7 @@ HashCSlots = simple_class(hash=True, slots=True)
 class InitC(object):
     __attrs_attrs__ = [simple_attr("a"), simple_attr("b")]
 
-InitC = _add_init(InitC)
+InitC = _add_init(InitC, False)
 
 
 class TestAddCmp(object):
@@ -219,12 +219,13 @@ class TestAddInit(object):
     """
     Tests for `_add_init`.
     """
-    @given(booleans())
-    def test_init(self, slots):
+    @given(booleans(), booleans())
+    def test_init(self, slots, frozen):
         """
         If `init` is False, ignore that attribute.
         """
-        C = make_class("C", {"a": attr(init=False), "b": attr()}, slots=slots)
+        C = make_class("C", {"a": attr(init=False), "b": attr()},
+                       slots=slots, frozen=frozen)
         with pytest.raises(TypeError) as e:
             C(a=1, b=2)
 
@@ -233,8 +234,8 @@ class TestAddInit(object):
             e.value.args[0]
         )
 
-    @given(booleans())
-    def test_no_init_default(self, slots):
+    @given(booleans(), booleans())
+    def test_no_init_default(self, slots, frozen):
         """
         If `init` is False but a Factory is specified, don't allow passing that
         argument but initialize it anyway.
@@ -243,7 +244,7 @@ class TestAddInit(object):
             "_a": attr(init=False, default=42),
             "_b": attr(init=False, default=Factory(list)),
             "c": attr()
-        }, slots=slots)
+        }, slots=slots, frozen=frozen)
         with pytest.raises(TypeError):
             C(a=1, c=2)
         with pytest.raises(TypeError):
@@ -252,8 +253,8 @@ class TestAddInit(object):
         i = C(23)
         assert (42, [], 23) == (i._a, i._b, i.c)
 
-    @given(booleans())
-    def test_no_init_order(self, slots):
+    @given(booleans(), booleans())
+    def test_no_init_order(self, slots, frozen):
         """
         If an attribute is `init=False`, it's legal to come after a mandatory
         attribute.
@@ -261,7 +262,7 @@ class TestAddInit(object):
         make_class("C", {
             "a": attr(default=Factory(list)),
             "b": attr(init=False),
-        }, slots=slots)
+        }, slots=slots, frozen=frozen)
 
     def test_sets_attributes(self):
         """
@@ -282,7 +283,7 @@ class TestAddInit(object):
                 simple_attr(name="c", default=None),
             ]
 
-        C = _add_init(C)
+        C = _add_init(C, False)
         i = C()
         assert 2 == i.a
         assert "hallo" == i.b
@@ -300,7 +301,7 @@ class TestAddInit(object):
                 simple_attr(name="a", default=Factory(list)),
                 simple_attr(name="b", default=Factory(D)),
             ]
-        C = _add_init(C)
+        C = _add_init(C, False)
         i = C()
         assert [] == i.a
         assert isinstance(i.b, D)
@@ -363,7 +364,7 @@ class TestAddInit(object):
         class C(object):
             __attrs_attrs__ = [simple_attr("_private")]
 
-        C = _add_init(C)
+        C = _add_init(C, False)
         i = C(private=42)
         assert 42 == i._private
 


### PR DESCRIPTION
First shot at immutability to fix #3 and #50.

I would very much like some input from y’all that asked for it:  @glyph @radix @Tinche 

A couple of notes:

- I didn’t go for a separate decorator because that would be confusing and harder to implement.
- I called it `frozen` because most Pythonista have heard of `frozenset`.  `immutable` is a bit long, `value` seems confusingly generic and only understandable to people with FP/theory background.
- Originally I wanted to just set `__setattr__` at the end of `__init__` but that doesn’t seem to work unfortunately.  So `object.setattr` it is.

***

I’m not set on any of those decisions and will happily be converted to any other way.  Just please keep in mind, that the feature has to be discoverable and understandable to people who just started programming.

Please paint this bikeshed.