### PR TITLE
Optimize init validators.

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -568,7 +568,8 @@ def _attrs_to_script(attrs, frozen):
     for a in attrs_to_validate:
         val_name = "__attr_validator_{}".format(a.name)
         attr_name = "__attr_{}".format(a.name)
-        lines.append("{}(self, {}, self.{})".format(val_name, attr_name, a.name))
+        lines.append("{}(self, {}, self.{})".format(val_name, attr_name,
+                                                    a.name))
         validators_for_globals[val_name] = a.validator
         validators_for_globals[attr_name] = a
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -401,7 +401,6 @@ def _add_init(cls, frozen):
         sha1.hexdigest()
     )
 
-<<<<<<< cfa6d2e99f3e14b90bf13f5969d6eb92b47d1399
     script, globs = _attrs_to_script(attrs, frozen)
     locs = {}
     bytecode = compile(script, unique_filename, "exec")

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -401,16 +401,17 @@ def _add_init(cls, frozen):
         sha1.hexdigest()
     )
 
-    script = _attrs_to_script(attrs, frozen)
+<<<<<<< cfa6d2e99f3e14b90bf13f5969d6eb92b47d1399
+    script, globs = _attrs_to_script(attrs, frozen)
     locs = {}
     bytecode = compile(script, unique_filename, "exec")
     attr_dict = dict((a.name, a) for a in attrs)
-    globs = {
+    globs.update({
         "NOTHING": NOTHING,
         "attr_dict": attr_dict,
         "validate": validate,
         "_convert": _convert
-    }
+    })
     if frozen is True:
         # Save the lookup overhead in __init__ if we need to circumvent
         # immutability.
@@ -482,9 +483,11 @@ def _convert(inst):
 
 def _attrs_to_script(attrs, frozen):
     """
-    Return a valid Python script of an initializer for *attrs*.
+    Return a script of an initializer for *attrs* and a dict of globals.
 
-    If *frozen* is True, we cannot set the attributes directly so we use
+    The globals are expected by the generated script.
+
+     If *frozen* is True, we cannot set the attributes directly so we use
     a cached ``object.__setattr__``.
     """
     lines = []
@@ -506,11 +509,16 @@ def _attrs_to_script(attrs, frozen):
             }
 
     args = []
-    has_validator = False
     has_convert = False
+    attrs_to_validate = []
+
+    # This is a dictionary of names to validator callables. Injecting
+    # this into __init__ globals lets us avoid lookups.
+    validators_for_globals = {}
+
     for a in attrs:
         if a.validator is not None:
-            has_validator = True
+            attrs_to_validate.append(a)
         if a.convert is not None:
             has_convert = True
         attr_name = a.name
@@ -553,8 +561,16 @@ def _attrs_to_script(attrs, frozen):
 
     if has_convert:
         lines.append("_convert(self)")
-    if has_validator:
-        lines.append("validate(self)")
+    if attrs_to_validate:  # we can skip this if there are no validators.
+        validators_for_globals["_config"] = _config
+        lines.append("if _config._run_validators is False:")
+        lines.append("    return")
+    for a in attrs_to_validate:
+        val_name = "__attr_validator_{}".format(a.name)
+        attr_name = "__attr_{}".format(a.name)
+        lines.append("{}(self, {}, self.{})".format(val_name, attr_name, a.name))
+        validators_for_globals[val_name] = a.validator
+        validators_for_globals[attr_name] = a
 
     return """\
 def __init__(self, {args}):
@@ -562,7 +578,7 @@ def __init__(self, {args}):
 """.format(
         args=", ".join(args),
         lines="\n    ".join(lines) if lines else "pass",
-    )
+    ), validators_for_globals
 
 
 class Attribute(object):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -465,8 +465,13 @@ class TestValidate(object):
             raise Exception(obj)
 
         C = make_class("C", {"x": attr(validator=raiser)})
-        assert 1 == C(1).x
+        c = C(1)
+        validate(c)
+        assert 1 == c.x
         _config._run_validators = True
+
+        with pytest.raises(Exception):
+            validate(c)
 
         with pytest.raises(Exception) as e:
             C(1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -121,7 +121,8 @@ simple_attrs = st.one_of(bare_attrs, int_attrs, str_attrs, float_attrs,
                          dict_attrs)
 
 # Python functions support up to 255 arguments.
-simple_classes = st.lists(simple_attrs, max_size=255).map(_create_hyp_class)
+simple_classes = (st.lists(simple_attrs, average_size=9, max_size=50)
+                  .map(_create_hyp_class))
 
 # Ok, so st.recursive works by taking a base strategy (in this case,
 # simple_classes) and a special function. This function receives a strategy,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -120,7 +120,8 @@ dict_attrs = (st.dictionaries(keys=st.text(), values=st.integers())
 simple_attrs = st.one_of(bare_attrs, int_attrs, str_attrs, float_attrs,
                          dict_attrs)
 
-simple_classes = st.lists(simple_attrs).map(_create_hyp_class)
+# Python functions support up to 255 arguments.
+simple_classes = st.lists(simple_attrs, max_size=255).map(_create_hyp_class)
 
 # Ok, so st.recursive works by taking a base strategy (in this case,
 # simple_classes) and a special function. This function receives a strategy,


### PR DESCRIPTION
OK, here's an idea for an optimization, since we're into that stuff now :)

Assume the attrs class `attr.make_class('C', {'x': attr.ib(validator=validators.instance_of(int)), 'y': attr.ib(), 'z': attr.ib()})`.

The master will generate an __init__ like this:

```
def __init__(self, x, y, z):
    self.x = x
    self.y = y
    self.z = z
    validate(self)
```

so I was thinking how to improve this. Ideas in sequence:
1. `validate()` calls `fields()`. Can we avoid the function call by using the `__attrs_attrs__` directly? `validate()` is a public facing API, so alas, no.
2. OK, so what if we don't even call `validate()`, and so avoid that call too? Just put the internal validation code in the generated `__init__`.
3. Now that the code is here, speed things up more by generating smart `__init__` validation code. We don't have to skip attributes without validators every time, we can just not generate the code in the first place.
4. We can put things we need in `globals` directly, avoid some dict lookups.

So now, the generated `__init__` code looks like this:
```
def __init__(self, x, y, z):
    self.x = x
    self.y = y
    self.z = z
    if _config._run_validators is False:
        return
    __attr_validator_x(self, __attr_x, self.x)
```

Before:
```
$ pyperf timeit --rigorous -g -s "import attr; from attr import validators; C = attr.make_class('C', {'x': attr.ib(validator=validators.instance_of(int)), 'y': attr.ib(), 'z': attr.ib()})" "C(1, 2, 3)"
........................................
2.73 us:  2 ########
2.76 us:  9 #####################################
2.78 us: 11 ##############################################
2.81 us: 13 ######################################################
2.83 us: 12 ##################################################
2.86 us: 19 ###############################################################################
2.88 us: 12 ##################################################
2.91 us: 11 ##############################################
2.93 us: 11 ##############################################
2.96 us:  7 #############################
2.98 us:  4 #################
3.01 us:  2 ########
3.03 us:  0 |
3.06 us:  2 ########
3.08 us:  1 ####
3.11 us:  0 |
3.13 us:  1 ####
3.16 us:  1 ####
3.18 us:  1 ####
3.21 us:  0 |
3.23 us:  1 ####

Median +- std dev: 2.87 us +- 0.09 us
```

After:
```
$ pyperf timeit --rigorous -g -s "import attr; from attr import validators; C = attr.make_class('C', {'x': attr.ib(validator=validators.instance_of(int)), 'y': attr.ib(), 'z': attr.ib()})" "C(1, 2, 3)"
........................................
1.36 us:  2 ###########
1.36 us:  2 ###########
1.37 us:  7 ########################################
1.38 us:  5 ############################
1.38 us:  6 ##################################
1.39 us:  8 #############################################
1.40 us: 10 ########################################################
1.40 us: 11 ##############################################################
1.41 us: 13 #########################################################################
1.42 us: 14 ###############################################################################
1.42 us:  7 ########################################
1.43 us:  7 ########################################
1.44 us:  9 ###################################################
1.45 us:  8 #############################################
1.45 us:  4 #######################
1.46 us:  0 |
1.47 us:  0 |
1.47 us:  4 #######################
1.48 us:  1 ######
1.49 us:  1 ######
1.49 us:  1 ######

Median +- std dev: 1.41 us +- 0.03 us
```

Even the case of no validators is faster since I omit the call to validate altogether. (~1%)

Complexity for performance. Worth it?