### PR TITLE
add attr docstring

### DIFF
--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -29,6 +29,7 @@ __version__ = "16.2.0.dev0"
 __title__ = "attrs"
 __description__ = "Attributes Without Boilerplate"
 __uri__ = "https://attrs.readthedocs.io/"
+__doc__ = __description__ + " <" + __uri__ + ">"
 
 __author__ = "Hynek Schlawack"
 __email__ = "hs@ox.cx"


### PR DESCRIPTION
The generated docstring merely points to the docs elsewhere.  I started with "{} <{}>".format, but I'm new to attrs and wasn't sure if that meets the requirement for all supported Python versions.