### PR TITLE
Add converters helper module

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -257,6 +257,78 @@ Validators
       C(x=None)
 
 
+.. _api_converters:
+
+Converters
+----------
+
+.. autofunction:: attr.converters.list_of
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib()
+      >>> @attr.s
+      ... class D(object):
+      ...     y = attr.ib(convert=attr.converters.list_of(C))
+      >>> data = {'y': [{'x': 3}, {'x': 4}] }
+      >>> D(**data)
+      D(y=[C(x=3), C(x=4)])
+
+.. autofunction:: attr.converters.set_of
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib()
+      >>> @attr.s
+      ... class D(object):
+      ...     y = attr.ib(convert=attr.converters.set_of(C))
+      >>> data = {'y': [{'x': 3}, {'x': 4}] }
+      >>> D(**data)
+      D(y={C(x=3), C(x=4)})
+
+
+.. autofunction:: attr.converters.frozenset_of
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib()
+      >>> @attr.s
+      ... class D(object):
+      ...     y = attr.ib(convert=attr.converters.frozenset_of(C))
+      >>> data = {'y': [{'x': 3}, {'x': 4}] }
+      >>> D(**data)
+      D(y=frozenset({C(x=3), C(x=4)}))
+
+
+.. autofunction:: attr.converters.from_dict
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib()
+      >>> @attr.s
+      ... class D(object):
+      ...     y = attr.ib(convert=attr.converters.from_dict(C))
+      >>> data = {'y': {'x': 3} }
+      >>> D(**data)
+      D(y=C(x=3))
+
+
 Deprecated APIs
 ---------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -277,6 +277,8 @@ Converters
       >>> data = {'y': [{'x': 3}, {'x': 4}] }
       >>> D(**data)
       D(y=[C(x=3), C(x=4)])
+      >>> D(y=[C(x=3), C(x=4)])
+      D(y=[C(x=3), C(x=4)])
 
 .. autofunction:: attr.converters.set_of
 
@@ -292,6 +294,8 @@ Converters
       ...     y = attr.ib(convert=attr.converters.set_of(C))
       >>> data = {'y': [{'x': 3}, {'x': 4}] }
       >>> D(**data)
+      D(y={C(x=3), C(x=4)})
+      >>> D(y=[C(x=3), C(x=4)])
       D(y={C(x=3), C(x=4)})
 
 
@@ -310,6 +314,8 @@ Converters
       >>> data = {'y': [{'x': 3}, {'x': 4}] }
       >>> D(**data)
       D(y=frozenset({C(x=3), C(x=4)}))
+      >>> D(y=[C(x=3), C(x=4)])
+      D(y=frozenset({C(x=3), C(x=4)}))
 
 
 .. autofunction:: attr.converters.from_dict
@@ -327,6 +333,8 @@ Converters
       >>> data = {'y': {'x': 3} }
       >>> D(**data)
       D(y=C(x=3))
+      >>> D(y=C(x=4))
+      D(y=C(x=4))
 
 
 Deprecated APIs

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -22,6 +22,7 @@ from ._config import (
 from . import exceptions
 from . import filters
 from . import validators
+from . import converters
 
 
 __version__ = "16.2.0.dev0"
@@ -50,6 +51,7 @@ __all__ = [
     "attrib",
     "attributes",
     "attrs",
+    "converters",
     "exceptions",
     "fields",
     "filters",

--- a/src/attr/converters.py
+++ b/src/attr/converters.py
@@ -1,0 +1,90 @@
+"""
+Commonly used conversion functions.
+"""
+
+
+from ._make import attr, attributes
+
+
+@attributes(repr=False, slots=True)
+class _ListOfConverter(object):
+    type = attr()
+
+    def __call__(self, src):
+        return [self.type(**attrs) for attrs in src]
+
+    def __repr__(self):
+        return (
+            "<list_of converter for type {type!r}>"
+            .format(type=self.type))
+
+
+def list_of(type):
+    """
+    Converter from an iterable of dicts of attributes to a list of a given type
+    using keyword arguments to the constructor.
+    """
+    return _ListOfConverter(type)
+
+
+@attributes(repr=False, slots=True)
+class _SetOfConverter(object):
+    type = attr()
+
+    def __call__(self, src):
+        return set(self.type(**item) for item in src)
+
+    def __repr__(self):
+        return (
+            "<set_of converter for type {type!r}>"
+            .format(type=self.type))
+
+
+def set_of(type):
+    """
+    Converter from an iterable of dicts of attributes to a set of a given type
+    using keyword arguments to the constructor.
+    """
+    return _SetOfConverter(type)
+
+
+@attributes(repr=False, slots=True)
+class _FrozensetOfConverter(object):
+    type = attr()
+
+    def __call__(self, src):
+        return frozenset(self.type(**item) for item in src)
+
+    def __repr__(self):
+        return (
+            "<frozenset_of converter for type {type!r}>"
+            .format(type=self.type))
+
+
+def frozenset_of(type):
+    """
+    Converter from an iterable of dicts of attributes to a set of a given type
+    using keyword arguments to the constructor.
+    """
+    return _FrozensetOfConverter(type)
+
+
+@attributes(repr=False, slots=True)
+class _FromDictConverter(object):
+    type = attr()
+
+    def __call__(self, src):
+        return self.type(**src)
+
+    def __repr__(self):
+        return (
+            "<from_dict converter for type {type!r}>"
+            .format(type=self.type))
+
+
+def from_dict(type):
+    """
+    Converter from a dict of attributes to a given type.
+    """
+
+    return _FromDictConverter(type)

--- a/src/attr/converters.py
+++ b/src/attr/converters.py
@@ -11,6 +11,9 @@ class _ListOfConverter(object):
     type = attr()
 
     def __call__(self, src):
+        """
+        We use a callable class to be able to change the ``__repr__``.
+        """
         return [self.type(**attrs) for attrs in src]
 
     def __repr__(self):
@@ -23,6 +26,9 @@ def list_of(type):
     """
     Converter from an iterable of dicts of attributes to a list of a given type
     using keyword arguments to the constructor.
+
+    :param type: The type in the resulting list
+    :type type: type
     """
     return _ListOfConverter(type)
 
@@ -32,6 +38,9 @@ class _SetOfConverter(object):
     type = attr()
 
     def __call__(self, src):
+        """
+        We use a callable class to be able to change the ``__repr__``.
+        """
         return set(self.type(**item) for item in src)
 
     def __repr__(self):
@@ -44,6 +53,9 @@ def set_of(type):
     """
     Converter from an iterable of dicts of attributes to a set of a given type
     using keyword arguments to the constructor.
+
+    :param type: The type in the resulting set
+    :type type: type
     """
     return _SetOfConverter(type)
 
@@ -53,6 +65,9 @@ class _FrozensetOfConverter(object):
     type = attr()
 
     def __call__(self, src):
+        """
+        We use a callable class to be able to change the ``__repr__``.
+        """
         return frozenset(self.type(**item) for item in src)
 
     def __repr__(self):
@@ -65,6 +80,9 @@ def frozenset_of(type):
     """
     Converter from an iterable of dicts of attributes to a set of a given type
     using keyword arguments to the constructor.
+
+    :param type: The type in the resulting frozenset
+    :type type: type
     """
     return _FrozensetOfConverter(type)
 
@@ -74,6 +92,9 @@ class _FromDictConverter(object):
     type = attr()
 
     def __call__(self, src):
+        """
+        We use a callable class to be able to change the ``__repr__``.
+        """
         return self.type(**src)
 
     def __repr__(self):
@@ -85,6 +106,9 @@ class _FromDictConverter(object):
 def from_dict(type):
     """
     Converter from a dict of attributes to a given type.
+
+    :param type: The type to convert to
+    :type type: type
     """
 
     return _FromDictConverter(type)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,112 @@
+"""
+Tests for attr.converters
+"""
+from __future__ import absolute_import, division, print_function
+
+import attr
+from attr.converters import list_of, set_of, from_dict
+
+
+@attr.s
+class MockAttrs(object):
+    a = attr.ib()
+
+
+class TestListOf(object):
+    """
+    Tests for `list_of`
+    """
+    def test_success(self):
+        """
+        Successfully create a list from an iterable of dicts
+        """
+        conv = list_of(MockAttrs)
+        data = [{'a': 1},
+                {'a': 2},
+                {'a': 3}]
+        assert conv(data) == [MockAttrs(a=1),
+                              MockAttrs(a=2),
+                              MockAttrs(a=3)]
+
+    def test_repr(self):
+        """
+        Returned converter has a useful `__repr__`
+        """
+        conv = list_of(MockAttrs)
+        assert ("<list_of converter for type {type!r}>"
+                .format(type=MockAttrs)
+                ) == repr(conv)
+
+
+class TestSetOf(object):
+    """
+    Tests for `set_of`
+    """
+    def test_success(self):
+        """
+        Successfully create a set from an iterable of dicts
+        """
+        conv = set_of(MockAttrs)
+        data = [{'a': 1},
+                {'a': 2},
+                {'a': 3}]
+        assert conv(data) == set([MockAttrs(a=1),
+                                  MockAttrs(a=2),
+                                  MockAttrs(a=3)])
+
+    def test_repr(self):
+        """
+        Returned converter has a useful `__repr__`
+        """
+        conv = set_of(MockAttrs)
+        assert ("<set_of converter for type {type!r}>"
+                .format(type=MockAttrs)
+                ) == repr(conv)
+
+
+class TestFrozensetOf(object):
+    """
+    Tests for `frozenset_of`
+    """
+    def test_success(self):
+        """
+        Successfully create a set from an iterable of dicts
+        """
+        conv = set_of(MockAttrs)
+        data = [{'a': 1},
+                {'a': 2},
+                {'a': 3}]
+        assert conv(data) == set([MockAttrs(a=1),
+                                  MockAttrs(a=2),
+                                  MockAttrs(a=3)])
+
+    def test_repr(self):
+        """
+        Returned converter has a useful `__repr__`
+        """
+        conv = set_of(MockAttrs)
+        assert ("<set_of converter for type {type!r}>"
+                .format(type=MockAttrs)
+                ) == repr(conv)
+
+
+class TestFromDict(object):
+    """
+    Tests for `from_dict`
+    """
+    def test_success(self):
+        """
+        Successfully create an instance from a dict
+        """
+        conv = from_dict(MockAttrs)
+        data = {'a': 1}
+        assert conv(data) == MockAttrs(a=1)
+
+    def test_repr(self):
+        """
+        Returned converter has a useful `__repr__`
+        """
+        conv = from_dict(MockAttrs)
+        assert ("<from_dict converter for type {type!r}>"
+                .format(type=MockAttrs)
+                ) == repr(conv)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -16,7 +16,7 @@ class TestListOf(object):
     """
     Tests for `list_of`
     """
-    def test_success(self):
+    def test_convert_dict(self):
         """
         Successfully create a list from an iterable of dicts
         """
@@ -28,7 +28,19 @@ class TestListOf(object):
                               MockAttrs(a=2),
                               MockAttrs(a=3)]
 
-    def test_repr(self):
+    def test_convert_cls(self):
+        """
+        Successfully create a set from an iterable of the given type
+        """
+        conv = list_of(MockAttrs)
+        data = [MockAttrs(a=1),
+                MockAttrs(a=2),
+                MockAttrs(a=3)]
+        assert conv(data) == [MockAttrs(a=1),
+                              MockAttrs(a=2),
+                              MockAttrs(a=3)]
+
+    def test_convert_repr(self):
         """
         Returned converter has a useful `__repr__`
         """
@@ -42,7 +54,7 @@ class TestSetOf(object):
     """
     Tests for `set_of`
     """
-    def test_success(self):
+    def test_convert_dict(self):
         """
         Successfully create a set from an iterable of dicts
         """
@@ -54,7 +66,19 @@ class TestSetOf(object):
                                   MockAttrs(a=2),
                                   MockAttrs(a=3)])
 
-    def test_repr(self):
+    def test_convert_cls(self):
+        """
+        Successfully create a set from an iterable of the given type
+        """
+        conv = set_of(MockAttrs)
+        data = [MockAttrs(a=1),
+                MockAttrs(a=2),
+                MockAttrs(a=3)]
+        assert conv(data) == set([MockAttrs(a=1),
+                                  MockAttrs(a=2),
+                                  MockAttrs(a=3)])
+
+    def test_convert_repr(self):
         """
         Returned converter has a useful `__repr__`
         """
@@ -68,9 +92,9 @@ class TestFrozensetOf(object):
     """
     Tests for `frozenset_of`
     """
-    def test_success(self):
+    def test_convert_dict(self):
         """
-        Successfully create a set from an iterable of dicts
+        Successfully create a frozenset from an iterable of dicts
         """
         conv = frozenset_of(MockAttrs)
         data = [{'a': 1},
@@ -80,7 +104,19 @@ class TestFrozensetOf(object):
                                         MockAttrs(a=2),
                                         MockAttrs(a=3)])
 
-    def test_repr(self):
+    def test_convert_cls(self):
+        """
+        Successfully create a frozenset from an iterable of the given type
+        """
+        conv = frozenset_of(MockAttrs)
+        data = [MockAttrs(a=1),
+                MockAttrs(a=2),
+                MockAttrs(a=3)]
+        assert conv(data) == frozenset([MockAttrs(a=1),
+                                        MockAttrs(a=2),
+                                        MockAttrs(a=3)])
+
+    def test_convert_repr(self):
         """
         Returned converter has a useful `__repr__`
         """
@@ -94,12 +130,20 @@ class TestFromDict(object):
     """
     Tests for `from_dict`
     """
-    def test_success(self):
+    def test_convert_dict(self):
         """
         Successfully create an instance from a dict
         """
         conv = from_dict(MockAttrs)
         data = {'a': 1}
+        assert conv(data) == MockAttrs(a=1)
+
+    def test_convert_cls(self):
+        """
+        If passed an instance of the type, do not convert
+        """
+        conv = from_dict(MockAttrs)
+        data = MockAttrs(a=1)
         assert conv(data) == MockAttrs(a=1)
 
     def test_repr(self):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -4,7 +4,7 @@ Tests for attr.converters
 from __future__ import absolute_import, division, print_function
 
 import attr
-from attr.converters import list_of, set_of, from_dict
+from attr.converters import list_of, set_of, frozenset_of, from_dict
 
 
 @attr.s
@@ -72,20 +72,20 @@ class TestFrozensetOf(object):
         """
         Successfully create a set from an iterable of dicts
         """
-        conv = set_of(MockAttrs)
+        conv = frozenset_of(MockAttrs)
         data = [{'a': 1},
                 {'a': 2},
                 {'a': 3}]
-        assert conv(data) == set([MockAttrs(a=1),
-                                  MockAttrs(a=2),
-                                  MockAttrs(a=3)])
+        assert conv(data) == frozenset([MockAttrs(a=1),
+                                        MockAttrs(a=2),
+                                        MockAttrs(a=3)])
 
     def test_repr(self):
         """
         Returned converter has a useful `__repr__`
         """
-        conv = set_of(MockAttrs)
-        assert ("<set_of converter for type {type!r}>"
+        conv = frozenset_of(MockAttrs)
+        assert ("<frozenset_of converter for type {type!r}>"
                 .format(type=MockAttrs)
                 ) == repr(conv)
 


### PR DESCRIPTION
This change adds `list_of`, `set_of`, `frozenset_of`, and `from_dict` in a new converters module. I found similar helper functions useful when converting from JSON with nested objects and arrays of objects.