### PR TITLE
Issue79 pickle 2

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -441,6 +441,11 @@ Slot classes are a little different than ordinary, dictionary-backed classes:
 - Since non-slot classes cannot be turned into slot classes after they have been created, ``attr.s(.., slots=True)`` will *replace* the class it is applied to with a copy.
   In almost all cases this isn't a problem, but we mention it for the sake of completeness.
 
+- Using pickle with slot classes require pickle protocol 2 or greater. Python 2 uses protocol 0 by default so the
+  protocol would need to be specified. Python 3 uses protocol 3 by default. You can support protocol 0 and 1 by
+  `creating <https://docs.python.org/2/library/pickle.html#object.__getstate__>`_ a ``__getstate__`` and
+  ``__setstate__`` method. Those methods are created for frozen slot classes because they don't pickle otherwise.
+
 All in all, setting ``slots=True`` is usually a very good idea.
 
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -160,13 +160,12 @@ def _slots_getstate__(obj):
     """Play nice with pickle"""
     return tuple(getattr(obj, a) for a in obj.__slots__)
 
+
 def _slots_setstate__(obj, state):
     """Play nice with pickle"""
     __bound_setattr = _obj_setattr.__get__(obj, Attribute)
     for name, value in zip(obj.__slots__, state):
         __bound_setattr(name, value)
-
-
 
 
 def attributes(maybe_cls=None, these=None, repr_ns=None,

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -234,7 +234,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         if frozen is True:
             cls.__setattr__ = _frozen_setattrs
             if slots is True:
-                # slots and frozen require __getstate__ and __setstate__ to work
+                # slots and frozen require __getstate__/__setstate__ to work
                 cls = _add_pickle(cls)
         if slots is True:
             cls_dict = dict(cls.__dict__)

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -156,18 +156,6 @@ def _frozen_setattrs(self, name, value):
     raise FrozenInstanceError()
 
 
-def _slots_getstate__(obj):
-    """Play nice with pickle"""
-    return tuple(getattr(obj, a.name) for a in fields(obj.__class__))
-
-
-def _slots_setstate__(obj, state):
-    """Play nice with pickle"""
-    __bound_setattr = _obj_setattr.__get__(obj, Attribute)
-    for a, value in zip(fields(obj.__class__), state):
-        __bound_setattr(a.name, value)
-
-
 def attributes(maybe_cls=None, these=None, repr_ns=None,
                repr=True, cmp=True, hash=True, init=True,
                slots=False, frozen=False):
@@ -245,6 +233,9 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
             cls = _add_init(cls, frozen)
         if frozen is True:
             cls.__setattr__ = _frozen_setattrs
+            if slots is True:
+                # slots and frozen require __getstate__ and __setstate__ to work
+                cls = _add_pickle(cls)
         if slots is True:
             cls_dict = dict(cls.__dict__)
             cls_dict["__slots__"] = tuple(ca_list)
@@ -257,10 +248,6 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
                 cls_name = getattr(cls, "__qualname__", cls.__name__)
             else:
                 cls_name = cls.__name__
-
-            cls_dict['__getstate__'] = _slots_getstate__
-            cls_dict['__setstate__'] = _slots_setstate__
-
             cls = type(cls_name, cls.__bases__, cls_dict)
 
         return cls
@@ -445,6 +432,23 @@ def _add_init(cls, frozen):
         unique_filename
     )
     cls.__init__ = init
+    return cls
+
+
+def _add_pickle(cls):
+    """Add pickle helpers, needed for frozen and slotted classes"""
+    def _slots_getstate__(obj):
+        """Play nice with pickle"""
+        return tuple(getattr(obj, a.name) for a in fields(obj.__class__))
+
+    def _slots_setstate__(obj, state):
+        """Play nice with pickle"""
+        __bound_setattr = _obj_setattr.__get__(obj, Attribute)
+        for a, value in zip(fields(obj.__class__), state):
+            __bound_setattr(a.name, value)
+
+    cls.__getstate__ = _slots_getstate__
+    cls.__setstate__ = _slots_setstate__
     return cls
 
 
@@ -645,6 +649,7 @@ class Attribute(object):
                           in Attribute.__slots__
                           if k != "name"))
 
+    # Don't use _add_pickle since fields(Attribute) doesn't work
     def __getstate__(self):
         """Play nice with pickle"""
         return tuple(getattr(self, name) for name in self.__slots__)

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+import pickle
 
 import pytest
 from hypothesis import given
@@ -10,7 +11,6 @@ from attr._compat import TYPE
 from attr._make import Attribute, NOTHING
 from attr.exceptions import FrozenInstanceError
 
-import pickle
 
 @attr.s
 class C1(object):
@@ -179,7 +179,9 @@ class TestDarkMagic(object):
         assert e.value.args[0] == "can't set attribute"
         assert 1 == frozen.x
 
-    @pytest.mark.parametrize("cls", [C1, C1Slots, C2, C2Slots, Super, SuperSlots, Sub, SubSlots, Frozen])
+    @pytest.mark.parametrize("cls",
+                             [C1, C1Slots, C2, C2Slots, Super, SuperSlots,
+                              Sub, SubSlots, Frozen])
     def test_pickle_attributes(self, cls):
         """
         Test that unpickling attributes works
@@ -187,7 +189,9 @@ class TestDarkMagic(object):
         for attribute in attr.fields(cls):
             assert attribute == pickle.loads(pickle.dumps(attribute))
 
-    @pytest.mark.parametrize("cls", [C1, C1Slots, C2, C2Slots, Super, SuperSlots, Sub, SubSlots, Frozen])
+    @pytest.mark.parametrize("cls",
+                             [C1, C1Slots, C2, C2Slots, Super, SuperSlots,
+                              Sub, SubSlots, Frozen])
     def test_pickle_object(self, cls):
         """
         Test that serializing an object works with attr classes
@@ -197,4 +201,3 @@ class TestDarkMagic(object):
         else:
             obj = cls(123)
         assert repr(obj) == repr(pickle.loads(pickle.dumps(obj)))
-

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -69,6 +69,11 @@ class Frozen(object):
     x = attr.ib()
 
 
+@attr.s(frozen=True, slots=False)
+class FrozenNoSlots(object):
+    x = attr.ib()
+
+
 class TestDarkMagic(object):
     """
     Integration tests.
@@ -181,18 +186,22 @@ class TestDarkMagic(object):
 
     @pytest.mark.parametrize("cls",
                              [C1, C1Slots, C2, C2Slots, Super, SuperSlots,
-                              Sub, SubSlots, Frozen])
-    def test_pickle_attributes(self, cls):
+                              Sub, SubSlots, Frozen, FrozenNoSlots])
+    @pytest.mark.parametrize("protocol",
+                             range(2, pickle.HIGHEST_PROTOCOL + 1))
+    def test_pickle_attributes(self, cls, protocol):
         """
         Test that unpickling attributes works
         """
         for attribute in attr.fields(cls):
-            assert attribute == pickle.loads(pickle.dumps(attribute))
+            assert attribute == pickle.loads(pickle.dumps(attribute, protocol))
 
     @pytest.mark.parametrize("cls",
                              [C1, C1Slots, C2, C2Slots, Super, SuperSlots,
-                              Sub, SubSlots, Frozen])
-    def test_pickle_object(self, cls):
+                              Sub, SubSlots, Frozen, FrozenNoSlots])
+    @pytest.mark.parametrize("protocol",
+                             range(2, pickle.HIGHEST_PROTOCOL + 1))
+    def test_pickle_object(self, cls, protocol):
         """
         Test that serializing an object works with attr classes
         """
@@ -200,4 +209,4 @@ class TestDarkMagic(object):
             obj = cls(123, 456)
         else:
             obj = cls(123)
-        assert repr(obj) == repr(pickle.loads(pickle.dumps(obj)))
+        assert repr(obj) == repr(pickle.loads(pickle.dumps(obj, protocol)))

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -179,7 +179,6 @@ class TestDarkMagic(object):
         assert e.value.args[0] == "can't set attribute"
         assert 1 == frozen.x
 
-
     @pytest.mark.parametrize("cls", [C1, C1Slots, C2, C2Slots, Super, SuperSlots, Sub, SubSlots, Frozen])
     def test_pickle_attributes(self, cls):
         """
@@ -187,4 +186,15 @@ class TestDarkMagic(object):
         """
         for attribute in attr.fields(cls):
             assert attribute == pickle.loads(pickle.dumps(attribute))
-        
+
+    @pytest.mark.parametrize("cls", [C1, C1Slots, C2, C2Slots, Super, SuperSlots, Sub, SubSlots, Frozen])
+    def test_pickle_object(self, cls):
+        """
+        Test that serializing an object works with attr classes
+        """
+        if len(attr.fields(cls)) == 2:
+            obj = cls(123, 456)
+        else:
+            obj = cls(123)
+        assert repr(obj) == repr(pickle.loads(pickle.dumps(obj)))
+

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -10,6 +10,7 @@ from attr._compat import TYPE
 from attr._make import Attribute, NOTHING
 from attr.exceptions import FrozenInstanceError
 
+import pickle
 
 @attr.s
 class C1(object):
@@ -177,3 +178,13 @@ class TestDarkMagic(object):
 
         assert e.value.args[0] == "can't set attribute"
         assert 1 == frozen.x
+
+
+    @pytest.mark.parametrize("cls", [C1, C1Slots, C2, C2Slots, Super, SuperSlots, Sub, SubSlots, Frozen])
+    def test_pickle_attributes(self, cls):
+        """
+        Test that unpickling attributes works
+        """
+        for attribute in attr.fields(cls):
+            assert attribute == pickle.loads(pickle.dumps(attribute))
+        


### PR DESCRIPTION
Fix for issue #79. Add `__getstate__` and `__setstate__` to classes with `slots=True`, including `attr.Attribute`. Added test to make sure objects work with pickle.