### PR TITLE
Improve tests, bandage assoc.

### DIFF
--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import copy
 
 from ._compat import iteritems
-from ._make import Attribute, NOTHING, fields, _obj_setattr
+from ._make import NOTHING, fields, _obj_setattr
 
 
 def asdict(inst, recurse=True, filter=None, dict_factory=dict,
@@ -87,9 +87,10 @@ def assoc(inst, **changes):
     :return: A copy of inst with *changes* incorporated.
     """
     new = copy.copy(inst)
+    attr_map = {a.name: a for a in new.__class__.__attrs_attrs__}
     for k, v in iteritems(changes):
-        a = getattr(new.__class__, k, NOTHING)
-        if a is NOTHING or not isinstance(a, Attribute):
+        a = attr_map.get(k, NOTHING)
+        if a is NOTHING:
             raise ValueError(
                 "{k} is not an attrs attribute on {cl}."
                 .format(k=k, cl=new.__class__)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -8,7 +8,7 @@ from collections import OrderedDict, Sequence, Mapping
 
 import pytest
 
-from hypothesis import given, strategies as st
+from hypothesis import assume, given, strategies as st
 
 from .utils import simple_classes, nested_classes
 
@@ -130,7 +130,7 @@ class TestAsDict(object):
         } == res
         assert isinstance(res, dict_factory)
 
-    @given(simple_classes, st.sampled_from(MAPPING_TYPES))
+    @given(simple_classes(), st.sampled_from(MAPPING_TYPES))
     def test_roundtrip(self, cls, dict_class):
         """
         Test dumping to dicts and back for Hypothesis-generated classes.
@@ -144,7 +144,7 @@ class TestAsDict(object):
 
         assert instance == roundtrip_instance
 
-    @given(simple_classes)
+    @given(simple_classes())
     def test_asdict_preserve_order(self, cls):
         """
         Field order should be preserved when dumping to OrderedDicts.
@@ -186,11 +186,12 @@ class TestAssoc(object):
     """
     Tests for `assoc`.
     """
-    def test_empty(self):
+    @given(slots=st.booleans(), frozen=st.booleans())
+    def test_empty(self, slots, frozen):
         """
         Empty classes without changes get copied.
         """
-        @attributes
+        @attributes(slots=slots, frozen=frozen)
         class C(object):
             pass
 
@@ -200,36 +201,39 @@ class TestAssoc(object):
         assert i1 is not i2
         assert i1 == i2
 
+    @given(simple_classes())
     def test_no_changes(self, C):
         """
         No changes means a verbatim copy.
         """
-        i1 = C(1, 2)
+        i1 = C()
         i2 = assoc(i1)
 
         assert i1 is not i2
         assert i1 == i2
 
-    def test_change(self, C):
+    @given(simple_classes(), st.integers())
+    def test_change(self, C, val):
         """
         Changes work.
         """
-        i = assoc(C(1, 2), x=42)
-        assert C(42, 2) == i
+        # Take the first attribute, and change it.
+        assume(fields(C))  # Skip classes with no attributes.
+        original = C()
+        attribute = fields(C)[0]
+        changed = assoc(original, **{attribute.name: val})
+        assert getattr(changed, attribute.name) == val
 
+    @given(simple_classes())
     def test_unknown(self, C):
         """
         Wanting to change an unknown attribute raises a ValueError.
         """
-        @attributes
-        class C(object):
-            x = attr()
-            y = 42
-
+        # No generated class will have a four letter attribute.
         with pytest.raises(ValueError) as e:
-            assoc(C(1), y=2)
+            assoc(C(), aaaa=2)
         assert (
-            "y is not an attrs attribute on {cls!r}.".format(cls=C),
+            "aaaa is not an attrs attribute on {cls!r}.".format(cls=C),
         ) == e.value.args
 
     def test_frozen(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -126,9 +126,35 @@ simple_attrs = st.one_of(bare_attrs, int_attrs, str_attrs, float_attrs,
 
 # Python functions support up to 255 arguments.
 list_of_attrs = st.lists(simple_attrs, average_size=9, max_size=50)
-simple_classes = list_of_attrs.map(_create_hyp_class)
+
+
+@st.composite
+def simple_classes(draw, slots=None, frozen=None):
+    """A strategy that generates classes with default non-attr attributes.
+
+    For example, this strategy might generate a class such as:
+
+    @attr.s(slots=True, frozen=True)
+    class HypClass:
+        a = attr.ib(default=1)
+        b = attr.ib(default=None)
+        c = attr.ib(default='text')
+        d = attr.ib(default=1.0)
+        c = attr.ib(default={'t': 1})
+
+    By default, all combinations of slots and frozen classes will be generated.
+    If `slots=True` is passed in, only slots classes will be generated, and
+    if `slots=False` is passed in, no slot classes will be generated. The same
+    applies to `frozen`.
+    """
+    attrs = draw(list_of_attrs)
+    frozen_flag = draw(st.booleans()) if frozen is None else frozen
+    slots_flag = draw(st.booleans()) if slots is None else slots
+
+    return make_class('HypClass', dict(zip(_gen_attr_names(), attrs)),
+                      slots=slots_flag, frozen=frozen_flag)
 
 # Ok, so st.recursive works by taking a base strategy (in this case,
 # simple_classes) and a special function. This function receives a strategy,
 # and returns another strategy (building on top of the base strategy).
-nested_classes = st.recursive(simple_classes, _create_hyp_nested_strategy)
+nested_classes = st.recursive(simple_classes(), _create_hyp_nested_strategy)


### PR DESCRIPTION
Ok, here's something easy to merge.

I've done some work on the simple_classes strategy. It's somewhat documented, takes some parameters, and implemented in a clearer way. This is in the hopes it will get used more by other contributors in tests.

I've then applied this strategy to assoc tests. The tests picked up failures right away. I've applied a dumb fix to assoc to make slot classes pass.

The tests picked up another failure though: if a class is both slots and frozen, assoc will fail deep in copy.copy. This isn't so easily fixed. 

Plot twist!

![](https://morbotron.com/img/S05E13/1149931.jpg)

Digging around in the source of copy.copy, I see mentions of pickling. Applying these changes on to #81 allows copy.copy() to copy slots+frozen classes.