### PR TITLE
remove unnecessary and ugly `exec_` compat hack

### DIFF
--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -17,9 +17,6 @@ if PY2:
     # TYPE is used in exceptions, repr(int) is different on Python 2 and 3.
     TYPE = "type"
 
-    def exec_(code, locals_, globals_):
-        exec("exec code in locals_, globals_")
-
     def iteritems(d):
         return d.iteritems()
 
@@ -30,9 +27,6 @@ else:
         return isinstance(klass, type)
 
     TYPE = "class"
-
-    def exec_(code, locals_, globals_):
-        exec(code, locals_, globals_)
 
     def iteritems(d):
         return d.items()

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -4,7 +4,7 @@ import hashlib
 import linecache
 
 from . import _config
-from ._compat import exec_, iteritems, isclass, iterkeys
+from ._compat import iteritems, isclass, iterkeys
 from .exceptions import FrozenInstanceError
 
 # This is used at least twice, so cache it here.
@@ -418,7 +418,7 @@ def _add_init(cls, frozen):
         # Save the lookup overhead in __init__ if we need to circumvent
         # immutability.
         globs["_cached_setattr"] = _obj_setattr
-    exec_(bytecode, globs, locs)
+    eval(bytecode, globs, locs)
     init = locs["__init__"]
 
     # In order of debuggers like PDB being able to step through the code,


### PR DESCRIPTION
The `eval` builtin does exactly this already, with the same signature even.