### PR TITLE
Introduce attribute metadata.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,10 +11,10 @@ The third digit is only for regressions.
 Changes:
 ^^^^^^^^
 
+- Attributes now can have user-defined metadata which greatly improves ``attrs`` extensibility.
+  `#96 <https://github.com/hynek/attrs/pull/96>`_
 - Don't overwrite ``__name__`` with ``__qualname__`` for ``attr.s(slots=True)`` classes.
   `#99 <https://github.com/hynek/attrs/issues/99>`_
-- Attributes can now have metadata dictionaries.
-  `#96 <https://github.com/hynek/attrs/pull/96>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ The third digit is only for regressions.
 Changes:
 ^^^^^^^^
 
-- Attributes now can have user-defined metadata which greatly improves ``attrs`` extensibility.
+- Attributes now can have user-defined metadata which greatly improves ``attrs``'s extensibility.
   `#96 <https://github.com/hynek/attrs/pull/96>`_
 - Don't overwrite ``__name__`` with ``__qualname__`` for ``attr.s(slots=True)`` classes.
   `#99 <https://github.com/hynek/attrs/issues/99>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changes:
 
 - Don't overwrite ``__name__`` with ``__qualname__`` for ``attr.s(slots=True)`` classes.
   `#99 <https://github.com/hynek/attrs/issues/99>`_
+- Attributes can now have metadata dictionaries.
+  `#96 <https://github.com/hynek/attrs/pull/96>`_
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,7 +69,7 @@ Core
       ... class C(object):
       ...     x = attr.ib()
       >>> C.x
-      Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None)
+      Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({}))
 
 
 .. autofunction:: attr.make_class
@@ -125,9 +125,9 @@ Helpers
       ...     x = attr.ib()
       ...     y = attr.ib()
       >>> attr.fields(C)
-      (Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None), Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None))
+      (Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({})), Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({})))
       >>> attr.fields(C)[1]
-      Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None)
+      Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({}))
       >>> attr.fields(C).y is attr.fields(C)[1]
       True
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -458,7 +458,7 @@ Slot classes are a little different than ordinary, dictionary-backed classes:
     ... class C(object):
     ...     x = attr.ib()
     >>> C.x
-    Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None)
+    Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({}))
     >>> @attr.s(slots=True)
     ... class C(object):
     ...     x = attr.ib()

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -422,7 +422,7 @@ All ``attrs`` attributes may include arbitrary metadata in the form on a read-on
     >>> attr.fields(C).x.metadata['my_metadata']
     1
 
-Metadata is currently not used by ``attrs``, and is generally meant to enable rich functionality in third-party libraries.
+Metadata is not used by ``attrs``, and is meant to enable rich functionality in third-party libraries.
 The metadata dictionary follows the normal dictionary rules: keys need to be hashable, and both keys and values are recommended to be immutable.
 
 If you're the author of a third-party library with ``attrs`` integration, please see :ref:`Extending Metadata <extending_metadata>`.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -405,6 +405,29 @@ Converters are run *before* validators, so you can use validators to check the f
     ValueError: x must be be at least 0.
 
 
+.. _metadata:
+
+Metadata
+--------
+
+All ``attrs`` attributes may include arbitrary metadata in the form on a read-only dictionary.
+
+.. doctest::
+
+    >>> @attr.s
+    ... class C(object):
+    ...    x = attr.ib(metadata={'my_metadata': 1})
+    >>> attr.fields(C).x.metadata
+    mappingproxy({'my_metadata': 1})
+    >>> attr.fields(C).x.metadata['my_metadata']
+    1
+
+Metadata is currently not used by ``attrs``, and is generally meant to enable rich functionality in third-party libraries.
+The metadata dictionary follows the normal dictionary rules: keys need to be hashable, and both keys and values are recommended to be immutable.
+
+If you're the author of a third-party library with ``attrs`` integration, please see :ref:`Extending Metadata <extending_metadata>`.
+
+
 .. _slots:
 
 Slots

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -17,7 +17,7 @@ So it is fairly simple to build your own decorators on top of ``attrs``:
    ... @attr.s
    ... class C(object):
    ...     a = attr.ib()
-   (Attribute(name='a', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None),)
+   (Attribute(name='a', default=NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({})),)
 
 
 .. warning::

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -51,11 +51,11 @@ Here are some tips for effective use of metadata:
 
 - To avoid metadata key collisions, consider exposing your metadata keys from your modules.::
 
-    from mylib import my_metadata_key
+    from mylib import MY_METADATA_KEY
 
     @attr.s
     class C(object):
-      x = attr.ib(metadata={my_metadata_key: 1})
+      x = attr.ib(metadata={MY_METADATA_KEY: 1})
 
   Metadata should be composable, so consider supporting this approach even if you decide implementing your metadata in one of the following ways.
 
@@ -64,15 +64,15 @@ Here are some tips for effective use of metadata:
 
   .. doctest::
 
-    >>> my_type_metadata = '__my_type_metadata'
+    >>> MY_TYPE_METADATA = '__my_type_metadata'
     >>>
     >>> def typed(cls, default=attr.NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata={}):
     ...     metadata = dict() if not metadata else metadata
-    ...     metadata[my_type_metadata] = cls
+    ...     metadata[MY_TYPE_METADATA] = cls
     ...     return attr.ib(default, validator, repr, cmp, hash, init, convert, metadata)
     >>>
     >>> @attr.s
     ... class C(object):
     ...     x = typed(int, default=1, init=False)
-    >>> attr.fields(C).x.metadata[my_type_metadata]
+    >>> attr.fields(C).x.metadata[MY_TYPE_METADATA]
     <class 'int'>

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -36,3 +36,41 @@ So it is fairly simple to build your own decorators on top of ``attrs``:
          pass
 
       f = a(b(original_f))
+
+.. _extending_metadata:
+
+Metadata
+--------
+
+If you're the author of a third-party library with ``attrs`` integration, you may want to take advantage of attribute metadata.
+
+Here are some tips for effective use of metadata:
+
+- Try making your metadata keys and values immutable. This keeps the entire ``Attribute`` instances immutable too.
+
+- To avoid metadata key collisions, consider exposing your metadata keys from your modules.::
+
+    from mylib import my_metadata_key
+
+    @attr.s
+    class C(object):
+      x = attr.ib(metadata={my_metadata_key: 1})
+
+  Metadata should be composable, so consider supporting this approach even if you decide implementing your metadata in one of the following ways.
+
+- Expose ``attr.ib`` wrappers for your specific metadata. This is a more graceful approach if your users don't require metadata from other libraries.
+
+  .. doctest::
+
+    >>> my_type_metadata = '__my_type_metadata'
+    >>>
+    >>> def typed(cls, default=attr.NOTHING, validator=None, repr=True, cmp=True, hash=True, init=True, convert=None, metadata={}):
+    ...     metadata = dict() if not metadata else metadata
+    ...     metadata[my_type_metadata] = cls
+    ...     return attr.ib(default, validator, repr, cmp, hash, init, convert, metadata)
+    >>>
+    >>> @attr.s
+    ... class C(object):
+    ...     x = typed(int, default=1, init=False)
+    >>> attr.fields(C).x.metadata[my_type_metadata]
+    <class 'int'>

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -46,7 +46,8 @@ If you're the author of a third-party library with ``attrs`` integration, you ma
 
 Here are some tips for effective use of metadata:
 
-- Try making your metadata keys and values immutable. This keeps the entire ``Attribute`` instances immutable too.
+- Try making your metadata keys and values immutable.
+  This keeps the entire ``Attribute`` instances immutable too.
 
 - To avoid metadata key collisions, consider exposing your metadata keys from your modules.::
 
@@ -58,7 +59,8 @@ Here are some tips for effective use of metadata:
 
   Metadata should be composable, so consider supporting this approach even if you decide implementing your metadata in one of the following ways.
 
-- Expose ``attr.ib`` wrappers for your specific metadata. This is a more graceful approach if your users don't require metadata from other libraries.
+- Expose ``attr.ib`` wrappers for your specific metadata.
+  This is a more graceful approach if your users don't require metadata from other libraries.
 
   .. doctest::
 

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+import types
 
 
 PY2 = sys.version_info[0] == 2
 
 
 if PY2:
-    import types
 
     # We 'bundle' isclass instead of using inspect as importing inspect is
     # fairly expensive (order of 10-15 ms for a modern machine in 2016)
@@ -22,6 +22,9 @@ if PY2:
 
     def iterkeys(d):
         return d.iterkeys()
+
+    # Python 2 is bereft of a read-only dict proxy.
+    metadata_proxy = dict
 else:
     def isclass(klass):
         return isinstance(klass, type)
@@ -33,3 +36,5 @@ else:
 
     def iterkeys(d):
         return d.keys()
+
+    metadata_proxy = types.MappingProxyType

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -26,7 +26,9 @@ if PY2:
 
     # Python 2 is bereft of a read-only dict proxy, so we make one!
     class ReadOnlyDict(IterableUserDict):
-        """Best-effort read-only dict wrapper."""
+        """
+        Best-effort read-only dict wrapper.
+        """
 
         def __setitem__(self, key, val):
             # We gently pretend we're a Python 3 mappingproxy.

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -8,6 +8,7 @@ PY2 = sys.version_info[0] == 2
 
 
 if PY2:
+    from UserDict import IterableUserDict
 
     # We 'bundle' isclass instead of using inspect as importing inspect is
     # fairly expensive (order of 10-15 ms for a modern machine in 2016)
@@ -23,8 +24,54 @@ if PY2:
     def iterkeys(d):
         return d.iterkeys()
 
-    # Python 2 is bereft of a read-only dict proxy.
-    metadata_proxy = dict
+    # Python 2 is bereft of a read-only dict proxy, so we make one!
+    class ReadOnlyDict(IterableUserDict):
+        """Best-effort read-only dict wrapper."""
+
+        def __setitem__(self, key, val):
+            # We gently pretend we're a Python 3 mappingproxy.
+            raise TypeError("'mappingproxy' object does not support item "
+                            "assignment")
+
+        def update(self, _):
+            # We gently pretend we're a Python 3 mappingproxy.
+            raise AttributeError("'mappingproxy' object has no attribute "
+                                 "'update'")
+
+        def __delitem__(self, _):
+            # We gently pretend we're a Python 3 mappingproxy.
+            raise TypeError("'mappingproxy' object does not support item "
+                            "deletion")
+
+        def clear(self):
+            # We gently pretend we're a Python 3 mappingproxy.
+            raise AttributeError("'mappingproxy' object has no attribute "
+                                 "'clear'")
+
+        def pop(self, key, default=None):
+            # We gently pretend we're a Python 3 mappingproxy.
+            raise AttributeError("'mappingproxy' object has no attribute "
+                                 "'pop'")
+
+        def popitem(self):
+            # We gently pretend we're a Python 3 mappingproxy.
+            raise AttributeError("'mappingproxy' object has no attribute "
+                                 "'popitem'")
+
+        def setdefault(self, key, default=None):
+            # We gently pretend we're a Python 3 mappingproxy.
+            raise AttributeError("'mappingproxy' object has no attribute "
+                                 "'setdefault'")
+
+        def __repr__(self):
+            # Override to be identical to the Python 3 version.
+            return "mappingproxy(" + repr(self.data) + ")"
+
+    def metadata_proxy(d):
+        res = ReadOnlyDict()
+        res.data.update(d)  # We blocked update, so we have to do it like this.
+        return res
+
 else:
     def isclass(klass):
         return isinstance(klass, type)
@@ -37,4 +84,5 @@ else:
     def iterkeys(d):
         return d.keys()
 
-    metadata_proxy = types.MappingProxyType
+    def metadata_proxy(d):
+        return types.MappingProxyType(dict(d))

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -753,6 +753,7 @@ class Attribute(object):
                 __bound_setattr(name, metadata_proxy(value) if value else
                                 _empty_metadata_singleton)
 
+
 _a = [Attribute(name=name, default=NOTHING, validator=None,
                 repr=True, cmp=True, hash=(name != "metadata"), init=True)
       for name in Attribute.__slots__]

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -11,7 +11,7 @@ from .exceptions import FrozenInstanceError, NotAnAttrsClassError
 
 # This is used at least twice, so cache it here.
 _obj_setattr = object.__setattr__
-_init_convert_pat = '__attr_convert_{}'
+_init_convert_pat = "__attr_convert_{}"
 _tuple_property_pat = "    {attr_name} = property(itemgetter({index}))"
 _empty_metadata_singleton = metadata_proxy({})
 
@@ -136,8 +136,8 @@ def _make_attr_tuple_class(cls_name, attr_names):
             ))
     else:
         attr_class_template.append("    pass")
-    globs = {'itemgetter': itemgetter}
-    eval(compile("\n".join(attr_class_template), '', 'exec'), globs)
+    globs = {"itemgetter": itemgetter}
+    eval(compile("\n".join(attr_class_template), "", "exec"), globs)
     return globs[attr_class_name]
 
 
@@ -287,7 +287,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
             for ca_name in ca_list:
                 # It might not actually be in there, e.g. if using 'these'.
                 cls_dict.pop(ca_name, None)
-            cls_dict.pop('__dict__', None)
+            cls_dict.pop("__dict__", None)
 
             qualname = getattr(cls, "__qualname__", None)
             cls = type(cls.__name__, cls.__bases__, cls_dict)
@@ -702,23 +702,23 @@ class Attribute(object):
 
     Plus *all* arguments of :func:`attr.ib`.
     """
-    __slots__ = ('name', 'default', 'validator', 'repr', 'cmp', 'hash', 'init',
-                 'convert', 'metadata')
+    __slots__ = ("name", "default", "validator", "repr", "cmp", "hash", "init",
+                 "convert", "metadata")
 
     def __init__(self, name, default, validator, repr, cmp, hash, init,
                  convert=None, metadata=None):
         # Cache this descriptor here to speed things up later.
         __bound_setattr = _obj_setattr.__get__(self, Attribute)
 
-        __bound_setattr('name', name)
-        __bound_setattr('default', default)
-        __bound_setattr('validator', validator)
-        __bound_setattr('repr', repr)
-        __bound_setattr('cmp', cmp)
-        __bound_setattr('hash', hash)
-        __bound_setattr('init', init)
-        __bound_setattr('convert', convert)
-        __bound_setattr('metadata', (metadata_proxy(metadata) if metadata
+        __bound_setattr("name", name)
+        __bound_setattr("default", default)
+        __bound_setattr("validator", validator)
+        __bound_setattr("repr", repr)
+        __bound_setattr("cmp", cmp)
+        __bound_setattr("hash", hash)
+        __bound_setattr("init", init)
+        __bound_setattr("convert", convert)
+        __bound_setattr("metadata", (metadata_proxy(metadata) if metadata
                                      else _empty_metadata_singleton))
 
     def __setattr__(self, name, value):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -49,7 +49,7 @@ Sentinel to indicate the lack of a value when ``None`` is ambiguous.
 
 def attr(default=NOTHING, validator=None,
          repr=True, cmp=True, hash=True, init=True,
-         convert=None, metadata=None):
+         convert=None, metadata={}):
     """
     Create a new attribute on a class.
 

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -23,6 +23,7 @@ class C1Slots(object):
     x = attr.ib(validator=attr.validators.instance_of(int))
     y = attr.ib()
 
+
 foo = None
 
 

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -35,6 +35,7 @@ HashCSlots = simple_class(hash=True, slots=True)
 class InitC(object):
     __attrs_attrs__ = [simple_attr("a"), simple_attr("b")]
 
+
 InitC = _add_init(InitC, False)
 
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -219,7 +219,8 @@ class TestAsTuple(object):
                     assert_proper_col_class(field_val, obj_tuple[index])
                 elif isinstance(field_val, (list, tuple)):
                     # This field holds a sequence of something.
-                    assert type(field_val) is type(obj_tuple[index])  # noqa: E721
+                    expected_type = type(obj_tuple[index])
+                    assert type(field_val) is expected_type  # noqa: E721
                     for obj_e, obj_tuple_e in zip(field_val, obj_tuple[index]):
                         if has(obj_e.__class__):
                             assert_proper_col_class(obj_e, obj_tuple_e)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -3,12 +3,12 @@ Tests for `attr._make`.
 """
 
 from __future__ import absolute_import, division, print_function
+from operator import attrgetter
 
 import pytest
 
 from hypothesis import given
-from hypothesis.strategies import (booleans, composite, dictionaries, integers,
-                                   lists, sampled_from, text, binary)
+from hypothesis.strategies import booleans, integers, lists, sampled_from, text
 
 from attr import _config
 from attr._compat import PY2
@@ -25,7 +25,8 @@ from attr._make import (
 )
 from attr.exceptions import NotAnAttrsClassError
 
-from .utils import simple_attr, simple_attrs, simple_classes, gen_attr_names
+from .utils import (gen_attr_names, list_of_attrs, simple_attr, simple_attrs,
+                    simple_attrs_without_metadata, simple_classes)
 
 attrs = simple_attrs.map(lambda c: Attribute.from_counting_attr('name', c))
 
@@ -104,7 +105,8 @@ class TestTransformAttrs(object):
             "No mandatory attributes allowed after an attribute with a "
             "default value or factory.  Attribute in question: Attribute"
             "(name='y', default=NOTHING, validator=None, repr=True, "
-            "cmp=True, hash=True, init=True, convert=None, metadata=None)",
+            "cmp=True, hash=True, init=True, convert=None, "
+            "metadata=mappingproxy({}))",
         ) == e.value.args
 
     def test_these(self):
@@ -515,22 +517,10 @@ class TestValidate(object):
         assert (obj,) == e.value.args
 
 
-@composite
-def simple_attrs_with_metadata(draw):
-    """Create a simple attribute with arbitrary metadata."""
-    c_attr = draw(simple_attrs)
-    keys = booleans() | binary() | integers() | text()
-    vals = booleans() | binary() | integers() | text()
-    metadata = draw(dictionaries(keys=keys, values=vals))
-
-    return _CountingAttr(c_attr.default, c_attr.validator, c_attr.repr,
-                         c_attr.cmp, c_attr.hash, c_attr.init, c_attr.convert,
-                         metadata)
-
-# Looks like Hypothesis will cache attributes, so they don't generate sorted.
-attrs_with_metadata = (lists(simple_attrs_with_metadata() | simple_attrs,
-                             average_size=5, max_size=20)
-                       .map(lambda l: sorted(l, key=lambda a: a.counter)))
+# Hypothesis seems to cache values, so the lists of attributes come out
+# unsorted.
+sorted_lists_of_attrs = list_of_attrs.map(
+    lambda l: sorted(l, key=attrgetter('counter')))
 
 
 class TestMetadata(object):
@@ -538,7 +528,7 @@ class TestMetadata(object):
     Tests for metadata handling.
     """
 
-    @given(attrs_with_metadata)
+    @given(sorted_lists_of_attrs)
     def test_metadata_present(self, list_of_attrs):
         """
         Assert dictionaries are copied and present.
@@ -547,6 +537,48 @@ class TestMetadata(object):
 
         for hyp_attr, class_attr in zip(list_of_attrs, fields(C)):
             if hyp_attr.metadata is None:
-                assert class_attr.metadata is None
+                # The default is a singleton empty dict.
+                assert class_attr.metadata is not None
+                assert len(class_attr.metadata) == 0
             else:
                 assert hyp_attr.metadata == class_attr.metadata
+
+                # Once more, just to assert getting items and iteration.
+                for k in class_attr.metadata:
+                    assert hyp_attr.metadata[k] == class_attr.metadata[k]
+                    assert (hyp_attr.metadata.get(k) ==
+                            class_attr.metadata.get(k))
+
+    @given(simple_classes(), text())
+    def test_metadata_immutability(self, C, string):
+        """
+        The metadata dict should be best-effort immutable.
+        """
+        for a in fields(C):
+            with pytest.raises(TypeError):
+                a.metadata[string] = string
+            with pytest.raises(AttributeError):
+                a.metadata.update({string: string})
+            with pytest.raises(AttributeError):
+                a.metadata.clear()
+            with pytest.raises(AttributeError):
+                a.metadata.setdefault(string, string)
+
+            for k in a.metadata:
+                # For some reason, Python 3's MappingProxyType throws an
+                # IndexError for deletes on a large integer key.
+                with pytest.raises((TypeError, IndexError)):
+                    del a.metadata[k]
+                with pytest.raises(AttributeError):
+                    a.metadata.pop(k)
+            with pytest.raises(AttributeError):
+                    a.metadata.popitem()
+
+    @given(lists(simple_attrs_without_metadata, min_size=2, max_size=5))
+    def test_empty_metadata_singleton(self, list_of_attrs):
+        """
+        All empty metadata attributes share the same empty metadata dict.
+        """
+        C = make_class('C', dict(zip(gen_attr_names(), list_of_attrs)))
+        for a in fields(C)[1:]:
+            assert a.metadata is fields(C)[0].metadata

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -28,7 +28,7 @@ from attr.exceptions import NotAnAttrsClassError
 from .utils import (gen_attr_names, list_of_attrs, simple_attr, simple_attrs,
                     simple_attrs_without_metadata, simple_classes)
 
-attrs = simple_attrs.map(lambda c: Attribute.from_counting_attr('name', c))
+attrs = simple_attrs.map(lambda c: Attribute.from_counting_attr("name", c))
 
 
 class TestCountingAttr(object):
@@ -520,7 +520,7 @@ class TestValidate(object):
 # Hypothesis seems to cache values, so the lists of attributes come out
 # unsorted.
 sorted_lists_of_attrs = list_of_attrs.map(
-    lambda l: sorted(l, key=attrgetter('counter')))
+    lambda l: sorted(l, key=attrgetter("counter")))
 
 
 class TestMetadata(object):
@@ -533,7 +533,7 @@ class TestMetadata(object):
         """
         Assert dictionaries are copied and present.
         """
-        C = make_class('C', dict(zip(gen_attr_names(), list_of_attrs)))
+        C = make_class("C", dict(zip(gen_attr_names(), list_of_attrs)))
 
         for hyp_attr, class_attr in zip(list_of_attrs, fields(C)):
             if hyp_attr.metadata is None:
@@ -579,6 +579,6 @@ class TestMetadata(object):
         """
         All empty metadata attributes share the same empty metadata dict.
         """
-        C = make_class('C', dict(zip(gen_attr_names(), list_of_attrs)))
+        C = make_class("C", dict(zip(gen_attr_names(), list_of_attrs)))
         for a in fields(C)[1:]:
             assert a.metadata is fields(C)[0].metadata

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -156,7 +156,7 @@ def simple_attrs_with_metadata(draw):
 simple_attrs = simple_attrs_without_metadata | simple_attrs_with_metadata()
 
 # Python functions support up to 255 arguments.
-list_of_attrs = st.lists(simple_attrs, average_size=5, max_size=20)
+list_of_attrs = st.lists(simple_attrs, average_size=3, max_size=9)
 
 
 @st.composite
@@ -188,4 +188,5 @@ def simple_classes(draw, slots=None, frozen=None):
 # Ok, so st.recursive works by taking a base strategy (in this case,
 # simple_classes) and a special function. This function receives a strategy,
 # and returns another strategy (building on top of the base strategy).
-nested_classes = st.recursive(simple_classes(), _create_hyp_nested_strategy)
+nested_classes = st.recursive(simple_classes(), _create_hyp_nested_strategy,
+                              max_leaves=10)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -130,6 +130,7 @@ def _create_hyp_nested_strategy(simple_class_strategy):
                      attrs_and_classes.map(dict_of_class),
                      attrs_and_classes.map(ordereddict_of_class))
 
+
 bare_attrs = st.just(attr.ib(default=None))
 int_attrs = st.integers().map(lambda i: attr.ib(default=i))
 str_attrs = st.text().map(lambda s: attr.ib(default=s))
@@ -154,6 +155,7 @@ def simple_attrs_with_metadata(draw):
     return attr.ib(c_attr.default, c_attr.validator, c_attr.repr,
                    c_attr.cmp, c_attr.hash, c_attr.init, c_attr.convert,
                    metadata)
+
 
 simple_attrs = simple_attrs_without_metadata | simple_attrs_with_metadata()
 
@@ -186,6 +188,7 @@ def simple_classes(draw, slots=None, frozen=None):
 
     return make_class('HypClass', dict(zip(gen_attr_names(), attrs)),
                       slots=slots_flag, frozen=frozen_flag)
+
 
 # Ok, so st.recursive works by taking a base strategy (in this case,
 # simple_classes) and a special function. This function receives a strategy,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,7 +55,7 @@ class TestSimpleClass(object):
         assert simple_class() is not simple_class()
 
 
-def _gen_attr_names():
+def gen_attr_names():
     """
     Generate names for attributes, 'a'...'z', then 'aa'...'zz'.
 
@@ -78,7 +78,7 @@ def _create_hyp_class(attrs):
     """
     A helper function for Hypothesis to generate attrs classes.
     """
-    return make_class('HypClass', dict(zip(_gen_attr_names(), attrs)))
+    return make_class('HypClass', dict(zip(gen_attr_names(), attrs)))
 
 
 def _create_hyp_nested_strategy(simple_class_strategy):
@@ -167,7 +167,7 @@ def simple_classes(draw, slots=None, frozen=None):
     frozen_flag = draw(st.booleans()) if frozen is None else frozen
     slots_flag = draw(st.booleans()) if slots is None else slots
 
-    return make_class('HypClass', dict(zip(_gen_attr_names(), attrs)),
+    return make_class('HypClass', dict(zip(gen_attr_names(), attrs)),
                       slots=slots_flag, frozen=frozen_flag)
 
 # Ok, so st.recursive works by taking a base strategy (in this case,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -143,7 +143,9 @@ simple_attrs_without_metadata = (bare_attrs | int_attrs | str_attrs |
 
 @st.composite
 def simple_attrs_with_metadata(draw):
-    """Create a simple attribute with arbitrary metadata."""
+    """
+    Create a simple attribute with arbitrary metadata.
+    """
     c_attr = draw(simple_attrs)
     keys = st.booleans() | st.binary() | st.integers() | st.text()
     vals = st.booleans() | st.binary() | st.integers() | st.text()


### PR DESCRIPTION
Alright, here's a first pass, open for comments. Docs will come after the implementation is settled.

The syntax is:

```
@attr.s
class A:
    a = attr.ib(metadata=<metadata>)
```

where `<metadata>` can be:
- None
- a mapping (technically something that can be passed to the dict constructor)

On Python 2, the metadata (if not None) will be exposed as a plain dict. On Python 3, the original, passed-in mapping will be wrapped in a https://docs.python.org/3.5/library/types.html#types.MappingProxyType.

I'm not entirely happy with None as the default here (it's my pet peeve to have Optional[Collection] instead of just an empty collection) but I feel an empty dict per attribute might be too much memory overhead? MappingProxyType would have solved this elegantly (we would have one empty instance, used everywhere where there was no metadata), but alas.

I've tried marking the metadata field as excluded from hashing but I don't think we care much about that. I put together a property test for this but it kept failing since the `default` field isn't excluded, and the default was getting set to `{}`. Guess we don't care about it too much? Doubt many people will make sets of Attributes.

As a bonus I've made _CountingAttr slotted. There's no reason it shouldn't be.
