### PR TITLE
Ensure the LICENSE file is included in wheel metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,7 @@ testpaths = tests
 
 [bdist_wheel]
 universal = 1
+
+[metadata]
+# ensure LICENSE is included in wheel metadata
+license_file = LICENSE


### PR DESCRIPTION
Without this small setup.cfg addition a built wheel does not contain your LICENSE file.
With this, the license file will be added to a built wheel metadata.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>