### PR TITLE
ENH: forbid delete attr from frozen class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
-
+- Raise ``FrozenInstanceError`` when trying to delete an attribute from
+  a frozen class. `#118 <https://github.com/hynek/attrs/pull/118>`__
 
 ----
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -201,6 +201,13 @@ def _frozen_setattrs(self, name, value):
     raise FrozenInstanceError()
 
 
+def _frozen_delattrs(self, name):
+    """
+    Attached to frozen classes as __delattr__.
+    """
+    raise FrozenInstanceError()
+
+
 def attributes(maybe_cls=None, these=None, repr_ns=None,
                repr=True, cmp=True, hash=True, init=True,
                slots=False, frozen=False, str=False):
@@ -291,6 +298,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
             cls = _add_init(cls, frozen)
         if frozen is True:
             cls.__setattr__ = _frozen_setattrs
+            cls.__delattr__ = _frozen_delattrs
             if slots is True:
                 # slots and frozen require __getstate__/__setstate__ to work
                 cls = _add_pickle(cls)

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -182,6 +182,9 @@ class TestDarkMagic(object):
         with pytest.raises(FrozenInstanceError) as e:
             frozen.x = 2
 
+        with pytest.raises(FrozenInstanceError) as e:
+            del frozen.x
+
         assert e.value.args[0] == "can't set attribute"
         assert 1 == frozen.x
 


### PR DESCRIPTION
Raise FrozenInstanceError when trying to delete an attribute from
a frozen class.

On non-frozen classes `del` results in un-shadowing the `attr.ib` object which is a bit surprising. 