### PR TITLE
Validating, __init__-based assoc.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,9 @@ The third digit is only for regressions.
 Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*none*
+- `assoc` will now construct a fresh instance rather than using `copy.copy`.
+  This means `assoc` no longer works on classes without the usual `attrs` initializer, and that `assoc`ing will now validate the changed attributes.
+  `#124 <https://github.com/hynek/attrs/pull/124>`_
 
 
 Deprecations:

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -151,7 +151,7 @@ def has(cls):
 
 def assoc(inst, **changes):
     """
-    Copy *inst* and apply *changes*.
+    Create a new instance, based on *inst* with *changes* applied.
 
     :param inst: Instance of a class with ``attrs`` attributes.
     :param changes: Keyword changes in the new copy.

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -165,14 +165,22 @@ def assoc(inst, **changes):
     :raise attr.exceptions.NotAnAttrsClassError: If *cls* is not an ``attrs``
         class.
     """
-    new = copy.copy(inst)
-    attrs = fields(inst.__class__)
-    for k, v in iteritems(changes):
-        a = getattr(attrs, k, NOTHING)
-        if a is NOTHING:
-            raise AttrsAttributeNotFoundError(
-                "{k} is not an attrs attribute on {cl}."
-                .format(k=k, cl=new.__class__)
-            )
-        _obj_setattr(new, k, v)
-    return new
+    cls = inst.__class__
+    for a in fields(cls):
+        attr_name = a.name  # To deal with private attributes.
+        if attr_name[0] == "_":
+            init_name = attr_name[1:]
+            if attr_name not in changes:
+                changes[init_name] = getattr(inst, attr_name)
+            else:
+                # attr_name is in changes, it needs to be translated.
+                changes[init_name] = changes.pop(attr_name)
+        else:
+            if attr_name not in changes:
+                changes[attr_name] = getattr(inst, attr_name)
+    try:
+        return cls(**changes)
+    except TypeError as exc:
+        k = exc.args[0].split("'")[1]
+        raise AttrsAttributeNotFoundError(
+            "{k} is not an attrs attribute on {cl}.".format(k=k, cl=cls))

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-import copy
-
 from ._compat import iteritems
-from ._make import NOTHING, fields, _obj_setattr
+from ._make import fields
 from .exceptions import AttrsAttributeNotFoundError
 
 


### PR DESCRIPTION
Here is  an ``__init__``-based `assoc` implementation that handles private attributes.

Using the same three classes from #116, I've done benchmark runs for all-public and all-private attributes on the classes. Private attributes add a slight overhead now, the old implementation was unaffected. Underscores in front of class names indicate private attributes were used.

```
                A                       B                      C
--------------------------------------------------------------------------------------
Old assoc:      10.6  us +- 0.3  us     12.7  us +- 0.2  us    14.8  us +- 0.3  us
New assoc:       2.07 us +- 0.06 us      5.23 us +- 0.13 us     8.83 us +- 0.28 us


                _A                      _B                     _C
--------------------------------------------------------------------------------------
Old assoc:      10.5  us +- 0.2  us     12.6  us +- 0.2 us     14.9 us +- 0.3 us
New assoc:       2.58 us +- 0.07 us      6.16 us +- 0.12 us    10.7 us +- 0.2 us
```

I'm pretty sure we could handle the users supplying both private and public attribute names (i.e. both setter and init syntax) with a tiny performance cost, but is it worth it? First of all,

> There should be one-- and preferably only one --obvious way to do it.

second, could there be corner cases? I can't think of any (
```
class A:
    _a = attr.ib()
   __a = attr.ib()
```
isn't one of them, fortunately :) but maybe there are some?

Doc change and CHANGELOG entry to come when we're satisfied with the implementation.